### PR TITLE
Several fixes based on the warnings generated by clang-analyzer (XCode's Build & Analyse)

### DIFF
--- a/src/hpdf_annotation.c
+++ b/src/hpdf_annotation.c
@@ -320,12 +320,12 @@ HPDF_LinkAnnot_SetBorderStyle  (HPDF_Annotation  annot,
 
         ret += HPDF_Array_AddNumber (dash, dash_on);
         ret += HPDF_Array_AddNumber (dash, dash_off);
+
+        if (ret != HPDF_OK)
+           return HPDF_CheckError (annot->error);
     }
 
-    if (ret != HPDF_OK)
-        return HPDF_CheckError (annot->error);
-
-    return ret;
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -486,7 +486,10 @@ HPDF_Annot_SetRGBColor (HPDF_Annotation annot, HPDF_RGBColor color)
     ret += HPDF_Array_AddReal (cArray, color.g);
     ret += HPDF_Array_AddReal (cArray, color.b);
 
-    return ret;
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode (annot->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -499,7 +502,7 @@ HPDF_Annot_SetCMYKColor (HPDF_Annotation annot, HPDF_CMYKColor color)
 
     cArray = HPDF_Array_New (annot->mmgr);
     if (!cArray)
-        return HPDF_Error_GetCode ( annot->error);
+        return HPDF_Error_GetCode (annot->error);
 
     ret += HPDF_Dict_Add (annot, "C", cArray);
     ret += HPDF_Array_AddReal (cArray, color.c);
@@ -507,7 +510,10 @@ HPDF_Annot_SetCMYKColor (HPDF_Annotation annot, HPDF_CMYKColor color)
     ret += HPDF_Array_AddReal (cArray, color.y);
     ret += HPDF_Array_AddReal (cArray, color.k);
 
-    return ret;
+    if (ret != HPDF_OK)
+        return HPDF_Error_GetCode (annot->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -525,7 +531,10 @@ HPDF_Annot_SetGrayColor (HPDF_Annotation annot, HPDF_REAL color)
     ret += HPDF_Dict_Add (annot, "C", cArray);
     ret += HPDF_Array_AddReal ( cArray, color);
 
-    return ret;
+    if (ret != HPDF_OK)
+        return HPDF_Error_GetCode ( annot->error);
+    
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -540,7 +549,7 @@ HPDF_Annot_SetNoColor (HPDF_Annotation annot)
     if (!cArray)
         return HPDF_Error_GetCode ( annot->error);
 
-    ret += HPDF_Dict_Add (annot, "C", cArray);
+    ret = HPDF_Dict_Add (annot, "C", cArray);
     
     return ret;
 }
@@ -554,7 +563,7 @@ HPDF_TextAnnot_SetIcon  (HPDF_Annotation  annot,
     if (!CheckSubType (annot, HPDF_ANNOT_TEXT_NOTES))
         return HPDF_INVALID_ANNOTATION;
 
-    if (icon < 0 || icon >= HPDF_ANNOT_ICON_EOF)
+    if (icon >= HPDF_ANNOT_ICON_EOF)
         return HPDF_RaiseError (annot->error, HPDF_ANNOT_INVALID_ICON,
                 (HPDF_STATUS)icon);
 
@@ -673,7 +682,10 @@ HPDF_MarkupAnnot_SetInteriorRGBColor (HPDF_Annotation  annot, HPDF_RGBColor colo
     ret += HPDF_Array_AddReal (cArray, color.g);
     ret += HPDF_Array_AddReal (cArray, color.b);
 
-    return ret;
+    if (ret != HPDF_OK)
+        return HPDF_Error_GetCode (annot->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -694,7 +706,10 @@ HPDF_MarkupAnnot_SetInteriorCMYKColor (HPDF_Annotation  annot, HPDF_CMYKColor co
     ret += HPDF_Array_AddReal (cArray, color.y);
     ret += HPDF_Array_AddReal (cArray, color.k);
 
-    return ret;
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode (annot->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -712,7 +727,10 @@ HPDF_MarkupAnnot_SetInteriorGrayColor (HPDF_Annotation  annot, HPDF_REAL color)/
     ret += HPDF_Dict_Add (annot, "IC", cArray);
     ret += HPDF_Array_AddReal (cArray, color);
 
-    return ret;
+    if (ret != HPDF_OK)
+        return HPDF_Error_GetCode ( annot->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -727,7 +745,7 @@ HPDF_MarkupAnnot_SetInteriorTransparent (HPDF_Annotation  annot) /* IC with No C
     if (!cArray)
         return HPDF_Error_GetCode ( annot->error);
 
-    ret += HPDF_Dict_Add (annot, "IC", cArray);
+    ret = HPDF_Dict_Add (annot, "IC", cArray);
 
     return ret;
 }
@@ -889,7 +907,11 @@ HPDF_TextMarkupAnnot_SetQuadPoints ( HPDF_Annotation annot, HPDF_Point lb, HPDF_
     ret += HPDF_Array_AddReal (quadPoints, lt.y);
     ret += HPDF_Array_AddReal (quadPoints, rt.x);
     ret += HPDF_Array_AddReal (quadPoints, rt.y);
-    return ret;
+
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode (quadPoints->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -910,7 +932,10 @@ HPDF_FreeTextAnnot_SetLineEndingStyle (HPDF_Annotation annot, HPDF_LineAnnotEndi
     ret += HPDF_Array_AddName (lineEndStyles, HPDF_LINE_ANNOT_ENDING_STYLE_NAMES[(HPDF_INT)startStyle]);
     ret += HPDF_Array_AddName (lineEndStyles, HPDF_LINE_ANNOT_ENDING_STYLE_NAMES[(HPDF_INT)endStyle]);
 
-    return ret;
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode (lineEndStyles->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -940,7 +965,10 @@ HPDF_MarkupAnnot_SetRectDiff (HPDF_Annotation  annot, HPDF_Rect  rect) /* RD ent
     ret += HPDF_Array_AddReal (array, rect.right);
     ret += HPDF_Array_AddReal (array, rect.top);
 
-    return ret;
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode (array->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -982,7 +1010,11 @@ HPDF_FreeTextAnnot_Set3PointCalloutLine ( HPDF_Annotation annot, HPDF_Point star
     ret += HPDF_Array_AddReal (clPoints, kneePoint.y);
     ret += HPDF_Array_AddReal (clPoints, endPoint.x);
     ret += HPDF_Array_AddReal (clPoints, endPoint.y);
-    return ret;
+
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode (clPoints->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -1004,7 +1036,11 @@ HPDF_FreeTextAnnot_Set2PointCalloutLine ( HPDF_Annotation annot, HPDF_Point star
     ret += HPDF_Array_AddReal (clPoints, startPoint.y);
     ret += HPDF_Array_AddReal (clPoints, endPoint.x);
     ret += HPDF_Array_AddReal (clPoints, endPoint.y);
-    return ret;
+
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode (clPoints->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -1023,7 +1059,10 @@ HPDF_MarkupAnnot_SetCloudEffect (HPDF_Annotation  annot, HPDF_INT cloudIntensity
     ret += HPDF_Dict_AddName ( borderEffect, "S", "C");
     ret += HPDF_Dict_AddNumber ( borderEffect, "I", cloudIntensity);
     
-    return ret;
+    if (ret != HPDF_OK)
+        return HPDF_Error_GetCode (annot->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -1049,6 +1088,9 @@ HPDF_LineAnnot_SetPosition (HPDF_Annotation annot,
     ret += HPDF_Array_AddReal (lineEndPoints, endPoint.x);
     ret += HPDF_Array_AddReal (lineEndPoints, endPoint.y);
 
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode ( lineEndPoints->error);
+
     lineEndStyles = HPDF_Array_New ( annot->mmgr);
     if ( !lineEndStyles)
         return HPDF_Error_GetCode ( annot->error);
@@ -1059,7 +1101,10 @@ HPDF_LineAnnot_SetPosition (HPDF_Annotation annot,
     ret += HPDF_Array_AddName (lineEndStyles, HPDF_LINE_ANNOT_ENDING_STYLE_NAMES[(HPDF_INT)startStyle]);
     ret += HPDF_Array_AddName (lineEndStyles, HPDF_LINE_ANNOT_ENDING_STYLE_NAMES[(HPDF_INT)endStyle]);
 
-    return ret;
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode ( lineEndStyles->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -1073,7 +1118,10 @@ HPDF_LineAnnot_SetLeader (HPDF_Annotation annot, HPDF_INT leaderLen, HPDF_INT le
     ret += HPDF_Dict_AddNumber ( annot, "LLE", leaderExtLen);
     ret += HPDF_Dict_AddNumber ( annot, "LLO", leaderOffsetLen);
 
-    return ret;
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode ( annot->error);
+
+    return HPDF_OK;
 }
 
 HPDF_EXPORT(HPDF_STATUS)
@@ -1086,6 +1134,9 @@ HPDF_LineAnnot_SetCaption (HPDF_Annotation annot, HPDF_BOOL showCaption, HPDF_Li
     ret += HPDF_Dict_AddBoolean ( annot, "Cap", showCaption);
     ret += HPDF_Dict_AddName( annot, "CP", HPDF_LINE_ANNOT_CAP_POSITION_NAMES[(HPDF_INT)position]);
 
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode ( annot->error);
+
     capOffset = HPDF_Array_New ( annot->mmgr);
     if ( !capOffset)
         return HPDF_Error_GetCode ( annot->error);
@@ -1096,7 +1147,10 @@ HPDF_LineAnnot_SetCaption (HPDF_Annotation annot, HPDF_BOOL showCaption, HPDF_Li
     ret += HPDF_Array_AddNumber (capOffset, horzOffset);
     ret += HPDF_Array_AddNumber (capOffset, vertOffset);
 
-    return ret;
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode (capOffset->error);
+
+    return HPDF_OK;
 }
 
 

--- a/src/hpdf_font_cid.c
+++ b/src/hpdf_font_cid.c
@@ -401,14 +401,14 @@ CIDFontType2_New (HPDF_Font parent, HPDF_Xref xref)
 
             if (w != dw) {
                 if (!tmp_array) {
-                    if ((ret = HPDF_Array_AddNumber (array, i)) != HPDF_OK)
+                    if (HPDF_Array_AddNumber (array, i) != HPDF_OK)
                         return NULL;
 
                     tmp_array = HPDF_Array_New (font->mmgr);
                     if (!tmp_array)
                         return NULL;
 
-                    if ((ret = HPDF_Array_Add (array, tmp_array)) != HPDF_OK)
+                    if (HPDF_Array_Add (array, tmp_array) != HPDF_OK)
                         return NULL;
                 }
 
@@ -424,8 +424,7 @@ CIDFontType2_New (HPDF_Font parent, HPDF_Xref xref)
             if (!attr->map_stream)
                 return NULL;
 
-            if ((ret = HPDF_Dict_Add (font, "CIDToGIDMap", attr->map_stream))
-                    != HPDF_OK)
+            if (HPDF_Dict_Add (font, "CIDToGIDMap", attr->map_stream) != HPDF_OK)
                 return NULL;
 
             for (i = 0; i < max; i++) {

--- a/src/hpdf_namedict.c
+++ b/src/hpdf_namedict.c
@@ -223,6 +223,9 @@ HPDF_EmbeddedFile_New  (HPDF_MMgr  mmgr,
     ret += HPDF_Dict_Add (ef, "EF", eff);
     ret += HPDF_Dict_Add (eff, "F", filestream);
 
+    if (ret != HPDF_OK)
+        return NULL;
+
     return ef;
 }
 

--- a/src/hpdf_page_operator.c
+++ b/src/hpdf_page_operator.c
@@ -67,12 +67,10 @@ HPDF_Page_SetLineWidth  (HPDF_Page  page,
     if (line_width < 0)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE, 0);
 
-    if ((ret = HPDF_Stream_WriteReal (attr->stream,
-                line_width)) != HPDF_OK)
+    if (HPDF_Stream_WriteReal (attr->stream, line_width) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream,
-                " w\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " w\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->line_width = line_width;
@@ -94,7 +92,7 @@ HPDF_Page_SetLineCap  (HPDF_Page     page,
     if (ret != HPDF_OK)
         return ret;
 
-    if (line_cap < 0 || line_cap >= HPDF_LINECAP_EOF)
+    if (line_cap >= HPDF_LINECAP_EOF)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE,
                 (HPDF_STATUS)line_cap);
 
@@ -127,18 +125,16 @@ HPDF_Page_SetLineJoin  (HPDF_Page      page,
     if (ret != HPDF_OK)
         return ret;
 
-    if (line_join < 0 || line_join >= HPDF_LINEJOIN_EOF)
+    if (line_join >= HPDF_LINEJOIN_EOF)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE,
                 (HPDF_STATUS)line_join);
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteInt (attr->stream,
-                (HPDF_UINT)line_join)) != HPDF_OK)
+    if (HPDF_Stream_WriteInt (attr->stream, (HPDF_UINT)line_join) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream,
-                " j\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " j\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->line_join = line_join;
@@ -165,10 +161,10 @@ HPDF_Page_SetMiterLimit  (HPDF_Page  page,
     if (miter_limit < 1)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE, 0);
 
-    if ((ret = HPDF_Stream_WriteReal (attr->stream, miter_limit)) != HPDF_OK)
+    if (HPDF_Stream_WriteReal (attr->stream, miter_limit) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " M\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " M\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->miter_limit = miter_limit;
@@ -267,12 +263,10 @@ HPDF_Page_SetFlat  (HPDF_Page  page,
     if (flatness > 100 || flatness < 0)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE, 0);
 
-    if ((ret = HPDF_Stream_WriteReal (attr->stream,
-                flatness)) != HPDF_OK)
+    if (HPDF_Stream_WriteReal (attr->stream, flatness) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream,
-                " i\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " i\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->flatness = flatness;
@@ -306,11 +300,10 @@ HPDF_Page_SetExtGState  (HPDF_Page        page,
     if (!local_name)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteEscapeName (attr->stream, local_name)) !=
-                HPDF_OK)
+    if (HPDF_Stream_WriteEscapeName (attr->stream, local_name) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " gs\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " gs\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     /* change objct class to read only. */
@@ -341,7 +334,7 @@ HPDF_Page_GSave  (HPDF_Page  page)
     if (!new_gstate)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "q\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "q\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate = new_gstate;
@@ -372,7 +365,7 @@ HPDF_Page_GRestore  (HPDF_Page  page)
 
     attr->gstate = new_gstate;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "Q\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "Q\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     return ret;
@@ -417,7 +410,7 @@ HPDF_Page_Concat  (HPDF_Page         page,
     pbuf = HPDF_FToA (pbuf, y, eptr);
     HPDF_StrCpy (pbuf, " cm\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     tm = attr->gstate->trans_matrix;
@@ -461,7 +454,7 @@ HPDF_Page_MoveTo  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, y, eptr);
     HPDF_StrCpy (pbuf, " m\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->cur_pos.x = x;
@@ -498,7 +491,7 @@ HPDF_Page_LineTo  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, y, eptr);
     HPDF_StrCpy (pbuf, " l\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->cur_pos.x = x;
@@ -545,7 +538,7 @@ HPDF_Page_CurveTo  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, y3, eptr);
     HPDF_StrCpy (pbuf, " c\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->cur_pos.x = x3;
@@ -586,7 +579,7 @@ HPDF_Page_CurveTo2  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, y3, eptr);
     HPDF_StrCpy (pbuf, " v\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->cur_pos.x = x3;
@@ -627,7 +620,7 @@ HPDF_Page_CurveTo3  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, y3, eptr);
     HPDF_StrCpy (pbuf, " y\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->cur_pos.x = x3;
@@ -650,7 +643,7 @@ HPDF_Page_ClosePath  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "h\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "h\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->cur_pos = attr->str_pos;
@@ -691,7 +684,7 @@ HPDF_Page_Rectangle  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, height, eptr);
     HPDF_StrCpy (pbuf, " re\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->cur_pos.x = x;
@@ -720,7 +713,7 @@ HPDF_Page_Stroke  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "S\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "S\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_PAGE_DESCRIPTION;
@@ -744,7 +737,7 @@ HPDF_Page_ClosePathStroke  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "s\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "s\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_PAGE_DESCRIPTION;
@@ -768,7 +761,7 @@ HPDF_Page_Fill  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "f\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "f\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_PAGE_DESCRIPTION;
@@ -792,7 +785,7 @@ HPDF_Page_Eofill  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "f*\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "f*\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_PAGE_DESCRIPTION;
@@ -816,7 +809,7 @@ HPDF_Page_FillStroke  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "B\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "B\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_PAGE_DESCRIPTION;
@@ -840,7 +833,7 @@ HPDF_Page_EofillStroke  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "B*\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "B*\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_PAGE_DESCRIPTION;
@@ -863,7 +856,7 @@ HPDF_Page_ClosePathFillStroke  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "b\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "b\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_PAGE_DESCRIPTION;
@@ -887,7 +880,7 @@ HPDF_Page_ClosePathEofillStroke  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "b*\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "b*\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_PAGE_DESCRIPTION;
@@ -911,7 +904,7 @@ HPDF_Page_EndPath  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "n\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "n\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_PAGE_DESCRIPTION;
@@ -937,7 +930,7 @@ HPDF_Page_Clip  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "W\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "W\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_CLIPPING_PATH;
@@ -959,7 +952,7 @@ HPDF_Page_Eoclip  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "W*\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "W*\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_CLIPPING_PATH;
@@ -985,7 +978,7 @@ HPDF_Page_BeginText  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "BT\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "BT\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gmode = HPDF_GMODE_TEXT_OBJECT;
@@ -1009,7 +1002,7 @@ HPDF_Page_EndText  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "ET\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "ET\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->text_pos = INIT_POS;
@@ -1039,10 +1032,10 @@ HPDF_Page_SetCharSpace  (HPDF_Page  page,
     if (value < HPDF_MIN_CHARSPACE || value > HPDF_MAX_CHARSPACE)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE, 0);
 
-    if ((ret = HPDF_Stream_WriteReal (attr->stream, value)) != HPDF_OK)
+    if (HPDF_Stream_WriteReal (attr->stream, value) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " Tc\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " Tc\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->char_space = value;
@@ -1069,10 +1062,10 @@ HPDF_Page_SetWordSpace  (HPDF_Page  page,
     if (value < HPDF_MIN_WORDSPACE || value > HPDF_MAX_WORDSPACE)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE, 0);
 
-    if ((ret = HPDF_Stream_WriteReal (attr->stream, value)) != HPDF_OK)
+    if (HPDF_Stream_WriteReal (attr->stream, value) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " Tw\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " Tw\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->word_space = value;
@@ -1100,10 +1093,10 @@ HPDF_Page_SetHorizontalScalling  (HPDF_Page  page,
             value > HPDF_MAX_HORIZONTALSCALING)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE, 0);
 
-    if ((ret = HPDF_Stream_WriteReal (attr->stream, value)) != HPDF_OK)
+    if (HPDF_Stream_WriteReal (attr->stream, value) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " Tz\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " Tz\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->h_scalling = value;
@@ -1127,10 +1120,10 @@ HPDF_Page_SetTextLeading  (HPDF_Page  page,
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteReal (attr->stream, value)) != HPDF_OK)
+    if (HPDF_Stream_WriteReal (attr->stream, value) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " TL\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " TL\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->text_leading = value;
@@ -1173,8 +1166,7 @@ HPDF_Page_SetFontAndSize  (HPDF_Page  page,
     if (!local_name)
         return HPDF_RaiseError (page->error, HPDF_PAGE_INVALID_FONT, 0);
 
-    if ((ret = HPDF_Stream_WriteEscapeName (attr->stream, local_name)) !=
-            HPDF_OK)
+    if (HPDF_Stream_WriteEscapeName (attr->stream, local_name) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     HPDF_MemSet (buf, 0, HPDF_TMP_BUF_SIZ);
@@ -1182,7 +1174,7 @@ HPDF_Page_SetFontAndSize  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, size, eptr);
     HPDF_StrCpy (pbuf, " Tf\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->font = font;
@@ -1206,16 +1198,16 @@ HPDF_Page_SetTextRenderingMode  (HPDF_Page               page,
     if (ret != HPDF_OK)
         return ret;
 
-    if (mode < 0 || mode >= HPDF_RENDERING_MODE_EOF)
+    if (mode >= HPDF_RENDERING_MODE_EOF)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE,
                 (HPDF_STATUS)mode);
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteInt (attr->stream, (HPDF_INT)mode)) != HPDF_OK)
+    if (HPDF_Stream_WriteInt (attr->stream, (HPDF_INT)mode) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " Tr\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " Tr\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->rendering_mode = mode;
@@ -1247,10 +1239,10 @@ HPDF_Page_SetTextRise  (HPDF_Page  page,
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteReal (attr->stream, value)) != HPDF_OK)
+    if (HPDF_Stream_WriteReal (attr->stream, value) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " Ts\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " Ts\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->text_rise = value;
@@ -1287,7 +1279,7 @@ HPDF_Page_MoveTextPos  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, y, eptr);
     HPDF_StrCpy (pbuf, " Td\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->text_matrix.x += x * attr->text_matrix.a + y * attr->text_matrix.c;
@@ -1324,7 +1316,7 @@ HPDF_Page_MoveTextPos2  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, y, eptr);
     HPDF_StrCpy (pbuf, " TD\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->text_matrix.x += x * attr->text_matrix.a + y * attr->text_matrix.c;
@@ -1377,7 +1369,7 @@ HPDF_Page_SetTextMatrix  (HPDF_Page         page,
     pbuf = HPDF_FToA (pbuf, y, eptr);
     HPDF_StrCpy (pbuf, " Tm\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->text_matrix.a = a;
@@ -1407,7 +1399,7 @@ HPDF_Page_MoveToNextLine  (HPDF_Page  page)
 
     attr = (HPDF_PageAttr)page->attr;
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, "T*\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, "T*\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     /* calculate the reference point of text */
@@ -1446,10 +1438,10 @@ HPDF_Page_ShowText  (HPDF_Page    page,
     if (!tw)
         return ret;
 
-    if ((ret = InternalWriteText (attr, text)) != HPDF_OK)
+    if (InternalWriteText (attr, text) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " Tj\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " Tj\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     /* calculate the reference point of text */
@@ -1488,10 +1480,10 @@ HPDF_Page_ShowTextNextLine  (HPDF_Page    page,
     if (text == NULL || text[0] == 0)
         return HPDF_Page_MoveToNextLine(page);
 
-    if ((ret = InternalWriteText (attr, text)) != HPDF_OK)
+    if (InternalWriteText (attr, text) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " \'\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " \'\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     tw = HPDF_Page_TextWidth (page, text);
@@ -1554,13 +1546,13 @@ HPDF_Page_ShowTextNextLineEx  (HPDF_Page    page,
     pbuf = HPDF_FToA (pbuf, char_space, eptr);
     *pbuf = ' ';
 
-    if ((ret = InternalWriteText (attr, buf)) != HPDF_OK)
+    if (InternalWriteText (attr, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = InternalWriteText (attr, text)) != HPDF_OK)
+    if (InternalWriteText (attr, text) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " \"\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " \"\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->word_space = word_space;
@@ -1616,10 +1608,10 @@ HPDF_Page_SetGrayFill  (HPDF_Page  page,
     if (gray < 0 || gray > 1)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE, 0);
 
-    if ((ret = HPDF_Stream_WriteReal (attr->stream, gray)) != HPDF_OK)
+    if (HPDF_Stream_WriteReal (attr->stream, gray) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " g\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " g\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->gray_fill = gray;
@@ -1647,10 +1639,10 @@ HPDF_Page_SetGrayStroke  (HPDF_Page  page,
     if (gray < 0 || gray > 1)
         return HPDF_RaiseError (page->error, HPDF_PAGE_OUT_OF_RANGE, 0);
 
-    if ((ret = HPDF_Stream_WriteReal (attr->stream, gray)) != HPDF_OK)
+    if (HPDF_Stream_WriteReal (attr->stream, gray) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " G\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " G\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->gray_stroke = gray;
@@ -1692,7 +1684,7 @@ HPDF_Page_SetRGBFill  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, b, eptr);
     HPDF_StrCpy (pbuf, " rg\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->rgb_fill.r = r;
@@ -1736,7 +1728,7 @@ HPDF_Page_SetRGBStroke  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, b, eptr);
     HPDF_StrCpy (pbuf, " RG\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->rgb_stroke.r = r;
@@ -1783,7 +1775,7 @@ HPDF_Page_SetCMYKFill  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, k, eptr);
     HPDF_StrCpy (pbuf, " k\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->cmyk_fill.c = c;
@@ -1831,7 +1823,7 @@ HPDF_Page_SetCMYKStroke  (HPDF_Page  page,
     pbuf = HPDF_FToA (pbuf, k, eptr);
     HPDF_StrCpy (pbuf, " K\012", eptr);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->gstate->cmyk_stroke.c = c;
@@ -1882,11 +1874,10 @@ HPDF_Page_ExecuteXObject  (HPDF_Page     page,
     if (!local_name)
         return HPDF_RaiseError (page->error, HPDF_PAGE_INVALID_XOBJECT, 0);
 
-    if ((ret = HPDF_Stream_WriteEscapeName (attr->stream, local_name)) !=
-                HPDF_OK)
+    if (HPDF_Stream_WriteEscapeName (attr->stream, local_name) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, " Do\012")) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, " Do\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     return ret;
@@ -2026,7 +2017,7 @@ HPDF_Page_Circle  (HPDF_Page     page,
     pbuf = QuarterCircleC (pbuf, eptr, x, y, ray);
     QuarterCircleD (pbuf, eptr, x, y, ray);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->cur_pos.x = x - ray;
@@ -2159,7 +2150,7 @@ HPDF_Page_Ellipse  (HPDF_Page   page,
     pbuf = QuarterEllipseC (pbuf, eptr, x, y, xray, yray);
     QuarterEllipseD (pbuf, eptr, x, y, xray, yray);
 
-    if ((ret = HPDF_Stream_WriteStr (attr->stream, buf)) != HPDF_OK)
+    if (HPDF_Stream_WriteStr (attr->stream, buf) != HPDF_OK)
         return HPDF_CheckError (page->error);
 
     attr->cur_pos.x = x - xray;
@@ -2564,7 +2555,7 @@ HPDF_Page_TextRect  (HPDF_Page            page,
                 }
         }
 
-        if ((ret = InternalShowTextNextLine (page, ptr, tmp_len)) != HPDF_OK)
+        if (InternalShowTextNextLine (page, ptr, tmp_len) != HPDF_OK)
             return HPDF_CheckError (page->error);
 
         if (num_rest <= 0)
@@ -2674,11 +2665,10 @@ HPDF_Page_SetSlideShow  (HPDF_Page            page,
     if (!dict)
         return HPDF_Error_GetCode (page->error);
 
-    if ((ret = HPDF_Dict_AddName (dict, "Type", "Trans")) != HPDF_OK)
+    if (HPDF_Dict_AddName (dict, "Type", "Trans") != HPDF_OK)
         goto Fail;
 
-    if ((ret = HPDF_Dict_AddReal (dict, "D", trans_time)) !=
-            HPDF_OK)
+    if (HPDF_Dict_AddReal (dict, "D", trans_time) != HPDF_OK)
         goto Fail;
 
     switch (type) {
@@ -2753,13 +2743,13 @@ HPDF_Page_SetSlideShow  (HPDF_Page            page,
             ret += HPDF_Dict_AddName  (dict, "S", "R");
             break;
         default:
-            ret = HPDF_INVALID_PAGE_SLIDESHOW_TYPE;
+            ret += HPDF_SetError(page->error, HPDF_INVALID_PAGE_SLIDESHOW_TYPE, 0);
     }
 
     if (ret != HPDF_OK)
         goto Fail;
 
-    if ((ret = HPDF_Dict_AddReal (page, "Dur", disp_time)) != HPDF_OK)
+    if (HPDF_Dict_AddReal (page, "Dur", disp_time) != HPDF_OK)
         goto Fail;
 
     if ((ret = HPDF_Dict_Add (page, "Trans", dict)) != HPDF_OK)

--- a/src/hpdf_pages.c
+++ b/src/hpdf_pages.c
@@ -165,11 +165,14 @@ HPDF_Page_InsertBefore  (HPDF_Page   page,
 
     HPDF_PTRACE((" HPDF_Page_InsertBefore\n"));
 
+    if (!target)
+        return HPDF_INVALID_PARAMETER;
+
     attr = (HPDF_PageAttr )target->attr;
     parent = attr->parent;
 
     if (!parent)
-        return HPDF_SetError (parent->error, HPDF_PAGE_CANNOT_SET_PARENT, 0);
+        return HPDF_PAGE_CANNOT_SET_PARENT;
 
     if (HPDF_Dict_GetItem (page, "Parent", HPDF_OCLASS_DICT))
         return HPDF_SetError (parent->error, HPDF_PAGE_CANNOT_SET_PARENT, 0);
@@ -460,14 +463,19 @@ AddResource  (HPDF_Page  page)
     if (!procset)
         return HPDF_Error_GetCode (page->error);
 
-    ret += HPDF_Dict_Add (resource, "ProcSet", procset);
+    if (HPDF_Dict_Add (resource, "ProcSet", procset) != HPDF_OK)
+        return HPDF_Error_GetCode (resource->error);
+
     ret += HPDF_Array_Add (procset, HPDF_Name_New (page->mmgr, "PDF"));
     ret += HPDF_Array_Add (procset, HPDF_Name_New (page->mmgr, "Text"));
     ret += HPDF_Array_Add (procset, HPDF_Name_New (page->mmgr, "ImageB"));
     ret += HPDF_Array_Add (procset, HPDF_Name_New (page->mmgr, "ImageC"));
     ret += HPDF_Array_Add (procset, HPDF_Name_New (page->mmgr, "ImageI"));
 
-    return ret;
+    if (ret != HPDF_OK)
+       return HPDF_Error_GetCode (procset->error);
+
+    return HPDF_OK;
 }
 
 
@@ -688,9 +696,12 @@ AddAnnotation  (HPDF_Page        page,
             return ret;
     }
     
-    ret += HPDF_Array_Add (array, annot);
+    if ((ret = HPDF_Array_Add (array, annot)) != HPDF_OK)
+       return ret;
+
     /* Add Parent to the annotation  */
-    ret += HPDF_Dict_Add( annot, "P", page);
+    ret = HPDF_Dict_Add( annot, "P", page);
+
     return ret;
 }
 

--- a/src/hpdf_streams.c
+++ b/src/hpdf_streams.c
@@ -154,7 +154,10 @@ HPDF_Stream_ReadLn  (HPDF_Stream  stream,
 
     HPDF_PTRACE((" HPDF_Stream_ReadLn\n"));
 
-    if (!stream || !s || *size == 0)
+    if (!stream)
+        return HPDF_INVALID_PARAMETER;
+
+    if (!s || *size == 0)
         return HPDF_SetError (stream->error, HPDF_INVALID_PARAMETER, 0);
 
     if (!(stream->seek_fn) || !(stream->read_fn))


### PR DESCRIPTION
Hi,

I’m using libharu in an iOS project. As of my 0 warning policy, I ran the clang-analyzer build into XCode over my sources. This report spit out a list of possible (and real) bugs in libharu.

Most of them were "variable never used" (as in ret += ...; ret += ...; if ((ret = ...)!= HPDF_OK) {} ) but there were others too (if (!parent) HPDF_SetError(parent->error,...);)

I fixed all of the warnings and some more errors. (E.g. there were quite a lot places where invalid error codes were returned: ret += ...; ret += ...; return ret;)
