### PR TITLE
fix for platforms where unsigned long is small to fit a pointer

### DIFF
--- a/src/hpdf_image_ccitt.c
+++ b/src/hpdf_image_ccitt.c
@@ -78,7 +78,7 @@ typedef struct {
 
 #define	Fax3State(tif)		(&(tif)->tif_data->b)
 #define	EncoderState(tif)	((tif)->tif_data)
-#define	isAligned(p,t)	((((unsigned long)(p)) & (sizeof (t)-1)) == 0)
+#define	isAligned(p,t)	((((size_t)(p)) & (sizeof (t)-1)) == 0)
 
 /* NB: the uint32 casts are to silence certain ANSI-C compilers */
 #define TIFFhowmany(x, y) ((((uint32)(x))+(((uint32)(y))-1))/((uint32)(y)))


### PR DESCRIPTION
modified isAligned() to not generate warnings on platforms
were 'unsigned long' is not large enough to hold pointer (Win64).
From: https://github.com/harbour/core/commit/adfcf7ad0403783e8963421b6e053886c66c265c