### PR TITLE
Embedded TrueType fonts not including all used glyphs

### DIFF
--- a/src/hpdf_fontdef_tt.c
+++ b/src/hpdf_fontdef_tt.c
@@ -1291,8 +1291,15 @@ CheckCompositGryph  (HPDF_FontDef   fontdef,
                     return ret;
             }
 
-            if (glyph_index > 0 && glyph_index < attr->num_glyphs)
+            if (glyph_index > 0 && glyph_index < attr->num_glyphs &&
+                    !attr->glyph_tbl.flgs[glyph_index]) {
+                HPDF_INT32 next_glyph;
+
                 attr->glyph_tbl.flgs[glyph_index] = 1;
+                next_glyph = HPDF_Stream_Tell (attr->stream);
+                CheckCompositGryph (fontdef, glyph_index);
+                HPDF_Stream_Seek (attr->stream, next_glyph, HPDF_SEEK_SET);
+            }
 
             HPDF_PTRACE ((" gid=%d, num_of_contours=%d, flags=%d, "
                     "glyph_index=%d\n", gid, num_of_contours, flags,


### PR DESCRIPTION
Subsetting TrueType fonts doesn't include all necessary glyphs for composite glyphs. The behaviour can e.g. be seen with umlaut characters when using FreeSans. Happens when a composite glyph references another composite glyph - the glyphs referenced by the second level composite glyph are no longer included in the embedded font.

Example (FreeSans): Adieresis consists of A and dieresis, dieresis consists of two dotaccent glyphs. Generated PDF would not include the definitions for dotaccent (unless included for another reason).

Suggested fix would be to recursively resolve those glyphs - please see the attached commit. Maybe there is a smarter way for resolving the glyphs than jumping forwards and backwards in the font stream?