### PR TITLE
Include the local include directory first.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ if(BUILD_SHARED_LIBS)
   set(LIBHPDF_SHARED ON)
 endif(BUILD_SHARED_LIBS)
 
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
 # =======================================================================
 # look for headers and libraries
 # =======================================================================
@@ -110,7 +112,6 @@ endif(PNG_FOUND)
 if(MSVC_VERSION GREATER 1399)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE)
 endif(MSVC_VERSION GREATER 1399)
-include_directories(${CMAKE_SOURCE_DIR}/include)
 
 
 # these are options


### PR DESCRIPTION
This fixes a problem when libharu in built on a system where a previous version
of libharu is installed and the structures have changed, e.g.,

[  4%] Building C object src/CMakeFiles/hpdf.dir/hpdf_annotation.o
/usr/ports/print/libharu/work/libharu-libharu-7f4bb51/src/hpdf_annotation.c:235:46:
error: use of undeclared identifier 'HPDF_ANNOT_WIDGET'; did you mean
'HPDF_ANNOT_HIDDEN'?
    annot = HPDF_Annotation_New (mmgr, xref, HPDF_ANNOT_WIDGET, rect);
                                             ^~~~~~~~~~~~~~~~~
                                             HPDF_ANNOT_HIDDEN
/usr/local/include/hpdf_types.h:366:5: note: 'HPDF_ANNOT_HIDDEN'
declared here
    HPDF_ANNOT_HIDDEN,
    ^
