### PR TITLE
Fixed two warnings when compiling Ruby extension.

### DIFF
--- a/if/ruby/hpdf.c
+++ b/if/ruby/hpdf.c
@@ -48,7 +48,7 @@ hpdf_error_handler  (HPDF_STATUS  error_no,
 {
     char msg[256];
 
-    snprintf(msg, 256, "ERROR 0x%04X-0x%04X", error_no, detail_no);
+    snprintf(msg, 256, "ERROR 0x%04lX-0x%04lX", error_no, detail_no);
 
     rb_raise(rb_eHPDFError, "%s", msg);
 }
@@ -1974,7 +1974,7 @@ hpdf_page_get_dash (VALUE obj)
     VALUE ret;
     VALUE num_ptn;
     VALUE phase;
-    HPDF_INT i;
+    HPDF_UINT i;
 
     Data_Get_Struct(obj, HPDF_Dict_Rec, page);
 


### PR DESCRIPTION
Fixed two tiny, isolated compiler warnings in the ruby extension code. They look like they've existed forever (fortunately they don't seem to break any functionality), from looking at the code history, but I could have sworn this was compiling totally cleanly in the past. Anyway, it appears either I'm going crazy or the Ruby Core and/or HPDF lowered the threshold for compiler warnings. (All equally likely.) This is not at all a complaint or anything, but I just wanted to point this out in case it wasn't intentional. (If it were I suspect you guys would have gone through all the warnings you turned on and spotted this.)

In any case, however minute the error, the code technically /was/ incorrect before, and clean code is always nice, especially when it's unimaginable how these fixes could break anything.. So I present them with my best wishes.

I used this extension code with the latest stable HPDF (v2.2.1) and it compiles cleanly now in the cutting-edge version of Ruby (which I believe is 2.1.2 -- don't quote me on the last digit). I would have tested it on your current dev version, but I didn't want to inject the uncertainty of whether a potential problem was with the extension or the library itself.

Let me know if there are any issues/things you'd like me to improve.

-------------------------------------------------------------------

- Fixed the format arg passed to printf on if/ruby/hpdf.c:51. The %X format
  specifier expects an int, but the type being passed to it, HPDF_STATUS is
  defined as a long. Prefixed the two 'X's with 'l's to remove compile warn.

- Resolved 2nd compile warning due to if/ruby/hpdf.c:1989. The iterator in
  the for loop was a HPDF_INT, but it was being compared against the
  'num_ptn' element of an HPDF_DashMode, which is defined as an HPDF_UINT.
  I simply made the iterator an HPDF_UINT as well, since it never needed
  to dip into negative territory anyway.