### PR TITLE
Setting MediaBox, CropBox, BleedBox, TrimBox, ArtBox page boundaries 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ CPackConfig.cmake
 CPackSourceConfig.cmake
 cmake_install.cmake
 depcomp
+/nbproject/

--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -252,6 +252,13 @@ HPDF_EXPORT(HPDF_STATUS)
 HPDF_Page_SetHeight  (HPDF_Page   page,
                       HPDF_REAL   value);
 
+HPDF_EXPORT(HPDF_STATUS)
+HPDF_Page_SetBoundary  (HPDF_Page           page,
+                        HPDF_PageBoundary   boundary,
+                        HPDF_REAL           left,
+                        HPDF_REAL           bottom,
+                        HPDF_REAL           right,
+                        HPDF_REAL           top);
 
 HPDF_EXPORT(HPDF_STATUS)
 HPDF_Page_SetSize  (HPDF_Page            page,

--- a/include/hpdf_error.h
+++ b/include/hpdf_error.h
@@ -145,6 +145,7 @@ extern "C" {
 #define HPDF_INVALID_U3D_DATA                     0x1083
 #define HPDF_NAME_CANNOT_GET_NAMES                0x1084
 #define HPDF_INVALID_ICC_COMPONENT_NUM            0x1085
+#define HPDF_PAGE_INVALID_BOUNDARY                0x1086
 
 /*---------------------------------------------------------------------------*/
 

--- a/include/hpdf_types.h
+++ b/include/hpdf_types.h
@@ -575,6 +575,14 @@ typedef enum _HPDF_NameDictKey {
     HPDF_NAME_EOF
 } HPDF_NameDictKey;
 
+typedef enum _HPDF_PageBoundary {
+    HPDF_PAGE_MEDIABOX = 0,
+    HPDF_PAGE_CROPBOX,
+    HPDF_PAGE_BLEEDBOX,
+    HPDF_PAGE_TRIMBOX,
+    HPDF_PAGE_ARTBOX
+} HPDF_PageBoundary;
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/hpdf_pages.c
+++ b/src/hpdf_pages.c
@@ -2322,3 +2322,40 @@ HPDF_Page_SetFilter  (HPDF_Page    page,
     attr->contents->filter = filter;
 }
 
+HPDF_EXPORT(HPDF_STATUS)
+HPDF_Page_SetBoundary  (HPDF_Page           page,
+                        HPDF_PageBoundary   boundary,
+                        HPDF_REAL           left,
+                        HPDF_REAL           bottom,
+                        HPDF_REAL           right,
+                        HPDF_REAL           top)
+{
+    
+    char *key;
+    
+    switch(boundary){
+        case HPDF_PAGE_MEDIABOX:
+            key = "MediaBox";
+            break;
+        case HPDF_PAGE_CROPBOX:
+            key = "CropBox";
+            break;
+        case HPDF_PAGE_BLEEDBOX:
+            key = "BleedBox";
+            break;
+        case HPDF_PAGE_TRIMBOX:
+            key = "TrimBox";
+            break;
+        case HPDF_PAGE_ARTBOX:
+            key = "ArtBox";
+            break;
+        default:
+            return HPDF_RaiseError(page->error, HPDF_PAGE_INVALID_BOUNDARY, 0);
+            break;
+    }
+    
+    return HPDF_Dict_Add (page, key, HPDF_Box_Array_New (page->mmgr,
+                HPDF_ToBox ((HPDF_INT16)left, (HPDF_INT16)bottom, (HPDF_INT16)right, (HPDF_INT16)top)));
+    
+}
+


### PR DESCRIPTION
Hello,
Added some code to allow for the setting of the different page boundaries. As far as I could tell only MediaBox is currently supported via the HPDF_Page_SetWidth and HPDF_Page_SetHeight functions.
