### PR TITLE
hpdf_pdfa.c: fix msvc warning

### DIFF
--- a/src/hpdf_pdfa.c
+++ b/src/hpdf_pdfa.c
@@ -283,7 +283,7 @@ HPDF_PDFA_SetPDFAConformance (HPDF_Doc pdf,HPDF_PDFAType pdfatype)
     return HPDF_OK;
 }
 
-/* Generate an ID for the trailer dict, PDF/A needs this. 
+/* Generate an ID for the trailer dict, PDF/A needs this.
    TODO: Better algorithm for generate unique ID.
 */
 HPDF_STATUS
@@ -293,32 +293,32 @@ HPDF_PDFA_GenerateID(HPDF_Doc pdf)
     HPDF_BYTE *currentTime;
     HPDF_BYTE idkey[HPDF_MD5_KEY_LEN];
     HPDF_MD5_CTX md5_ctx;
-    time_t ltime; 
+    time_t ltime;
 
-    ltime = time(NULL); 
+    ltime = time(NULL);
     currentTime = (HPDF_BYTE *)ctime(&ltime);
-        
+
     id = HPDF_Dict_GetItem(pdf->trailer, "ID", HPDF_OCLASS_ARRAY);
     if (!id) {
        id = HPDF_Array_New(pdf->mmgr);
 
        if (!id || HPDF_Dict_Add(pdf->trailer, "ID", id) != HPDF_OK)
          return pdf->error.error_no;
-       
+
        HPDF_MD5Init(&md5_ctx);
        HPDF_MD5Update(&md5_ctx, (HPDF_BYTE *) "libHaru", sizeof("libHaru") - 1);
        HPDF_MD5Update(&md5_ctx, currentTime, HPDF_StrLen((const char *)currentTime, -1));
        HPDF_MD5Final(idkey, &md5_ctx);
-       
+
        if (HPDF_Array_Add (id, HPDF_Binary_New (pdf->mmgr, idkey, HPDF_MD5_KEY_LEN)) != HPDF_OK)
          return pdf->error.error_no;
 
        if (HPDF_Array_Add (id, HPDF_Binary_New (pdf->mmgr,idkey,HPDF_MD5_KEY_LEN)) != HPDF_OK)
          return pdf->error.error_no;
-    
+
        return HPDF_OK;
     }
-    
+
     return HPDF_OK;
 }
 

--- a/src/hpdf_pdfa.c
+++ b/src/hpdf_pdfa.c
@@ -373,7 +373,7 @@ HPDF_PDFA_AppendOutputIntents(HPDF_Doc pdf, const char *iccname, HPDF_Dict iccdi
     if (intents == NULL) {
         intents = HPDF_Array_New (pdf->mmgr);
         if (intents) {
-            HPDF_STATUS ret = HPDF_Dict_Add (pdf->catalog, "OutputIntents", intents);
+            ret = HPDF_Dict_Add (pdf->catalog, "OutputIntents", intents);
             if (ret != HPDF_OK) {
                 HPDF_CheckError (&pdf->error);
                 return HPDF_Error_GetDetailCode (&pdf->error);


### PR DESCRIPTION
Local declaration of 'ret' hides declaration of the same name in outer scope