### PR TITLE
hpdf_pages.c: delete double defined values

### DIFF
--- a/src/hpdf_pages.c
+++ b/src/hpdf_pages.c
@@ -1261,8 +1261,6 @@ HPDF_Page_GetTextRise  (HPDF_Page   page)
 HPDF_EXPORT(HPDF_RGBColor)
 HPDF_Page_GetRGBFill  (HPDF_Page   page)
 {
-    HPDF_RGBColor DEF_RGB_COLOR = {0, 0, 0};
-
     HPDF_PTRACE((" HPDF_Page_GetRGBFill\n"));
 
     if (HPDF_Page_Validate (page)) {
@@ -1279,8 +1277,6 @@ HPDF_Page_GetRGBFill  (HPDF_Page   page)
 HPDF_EXPORT(HPDF_RGBColor)
 HPDF_Page_GetRGBStroke  (HPDF_Page   page)
 {
-    HPDF_RGBColor DEF_RGB_COLOR = {0, 0, 0};
-
     HPDF_PTRACE((" HPDF_Page_GetRGBStroke\n"));
 
     if (HPDF_Page_Validate (page)) {
@@ -1296,8 +1292,6 @@ HPDF_Page_GetRGBStroke  (HPDF_Page   page)
 HPDF_EXPORT(HPDF_CMYKColor)
 HPDF_Page_GetCMYKFill  (HPDF_Page   page)
 {
-    HPDF_CMYKColor DEF_CMYK_COLOR = {0, 0, 0, 0};
-
     HPDF_PTRACE((" HPDF_Page_GetCMYKFill\n"));
 
     if (HPDF_Page_Validate (page)) {
@@ -1314,8 +1308,6 @@ HPDF_Page_GetCMYKFill  (HPDF_Page   page)
 HPDF_EXPORT(HPDF_CMYKColor)
 HPDF_Page_GetCMYKStroke  (HPDF_Page   page)
 {
-    HPDF_CMYKColor DEF_CMYK_COLOR = {0, 0, 0, 0};
-
     HPDF_PTRACE((" HPDF_Page_GetCMYKStroke\n"));
 
     if (HPDF_Page_Validate (page)) {
@@ -2321,4 +2313,3 @@ HPDF_Page_SetFilter  (HPDF_Page    page,
     attr = (HPDF_PageAttr)page->attr;
     attr->contents->filter = filter;
 }
-


### PR DESCRIPTION
Fixes:
2x: warning C6244: Local declaration of 'DEF_RGB_COLOR' hides previous declaration
2x: warning C6244: Local declaration of 'DEF_CMYK_COLOR' hides previous declaration