### PR TITLE
silly typo :)

### DIFF
--- a/src/hpdf_annotation.c
+++ b/src/hpdf_annotation.c
@@ -37,9 +37,9 @@ static const char * const HPDF_ANNOT_TYPE_NAMES[] = {
                                         "Popup",
                                         "3D",
                                         "Squiggly",
-										"Line",
-										"Projection"
-										"Widget"
+					"Line",
+					"Projection",
+					"Widget"
                                         };
 
 static const char * const HPDF_ANNOT_ICON_NAMES_NAMES[] = {


### PR DESCRIPTION
The absence of the comma concatenates "Projection" and "Widget" to "ProjectionWidget". As result, if you create measurement associated with Projection Annotation, Adobe reader crashes on right-click on the created measurement.