### PR TITLE
Update docs link

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -1,2 +1,2 @@
 Please refer to online version of the documentation:
-http://libharu.org/wiki/Documentation
+https://github.com/libharu/libharu/wiki


### PR DESCRIPTION
Proposed: use GitHub wiki link instead of broken site link.