### PR TITLE
* Change HPDF_Page_CreateXObjectFromImage zoom parameter type to HPDF…

### DIFF
--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -461,7 +461,7 @@ HPDF_Page_CreateXObjectFromImage    (HPDF_Doc       pdf,
                                      HPDF_Page      page,
                                      HPDF_Rect      rect,
                                      HPDF_Image     image,
-                                     HPDF_Boolean   zoom);
+                                     HPDF_BOOL      zoom);
 
 HPDF_EXPORT(HPDF_XObject)
 HPDF_Page_CreateXObjectAsWhiteRect  (HPDF_Doc   pdf,

--- a/src/hpdf_pages.c
+++ b/src/hpdf_pages.c
@@ -582,7 +582,7 @@ HPDF_Page_CreateXObjectFromImage(HPDF_Doc       pdf,
                                  HPDF_Page      page,
                                  HPDF_Rect      rect,
                                  HPDF_Image     image,
-                                 HPDF_Boolean   zoom)
+                                 HPDF_BOOL      zoom)
 {
     HPDF_Dict resource;
     HPDF_Dict fromxobject;


### PR DESCRIPTION
Proposed fix for the example breakage issue on Windows (Issue #104)
