### PR TITLE
Reajust bit_depth of png image after striping depth from 16 to 8 so t…

### DIFF
--- a/src/hpdf_image_png.c
+++ b/src/hpdf_image_png.c
@@ -460,6 +460,7 @@ LoadPngData  (HPDF_Dict     image,
 	/* 16bit images are not supported. */
 	if (bit_depth == 16) {
 		png_set_strip_16(png_ptr);
+		bit_depth = 8;
 	}
 
 	png_read_update_info(png_ptr, info_ptr);


### PR DESCRIPTION
…he generated PDF to contain the right BitsPerComponent value.
