### PR TITLE
Fix missing /CapHeight key in font definition

### DIFF
--- a/src/hpdf_font_cid.c
+++ b/src/hpdf_font_cid.c
@@ -553,6 +553,7 @@ CIDFontType2_BeforeWrite_Func  (HPDF_Dict obj)
         ret += HPDF_Dict_AddName (descriptor, "Type", "FontDescriptor");
         ret += HPDF_Dict_AddNumber (descriptor, "Ascent", def->ascent);
         ret += HPDF_Dict_AddNumber (descriptor, "Descent", def->descent);
+        ret += HPDF_Dict_AddNumber (descriptor, "CapHeight", def->cap_height);
         ret += HPDF_Dict_AddNumber (descriptor, "Flags", def->flags);
 
         array = HPDF_Box_Array_New (obj->mmgr, def->font_bbox);


### PR DESCRIPTION
Issue found via PDF conformance check using
https://www.pdf-online.com/osa/validate.aspx