### PR TITLE
support of OpenType fonts

### DIFF
--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -910,6 +910,18 @@ HPDF_EXPORT(HPDF_INT)
 HPDF_Font_GetDescent  (HPDF_Font  font);
 
 
+HPDF_EXPORT(HPDF_INT)
+HPDF_Font_GetLeading  (HPDF_Font  font);
+
+
+HPDF_EXPORT(HPDF_INT)
+HPDF_Font_GetUnderlinePosition  (HPDF_Font  font);
+
+
+HPDF_EXPORT(HPDF_INT)
+HPDF_Font_GetUnderlineThickness  (HPDF_Font  font);
+
+
 HPDF_EXPORT(HPDF_UINT)
 HPDF_Font_GetXHeight  (HPDF_Font  font);
 

--- a/include/hpdf_doc.h
+++ b/include/hpdf_doc.h
@@ -31,7 +31,11 @@
 extern "C" {
 #endif
 
+#ifdef HPDF_OPENTYPE_PDF16
+#define HPDF_VER_DEFAULT  HPDF_VER_16
+#else
 #define HPDF_VER_DEFAULT  HPDF_VER_12
+#endif
 
 typedef struct _HPDF_Doc_Rec {
     HPDF_UINT32     sig_bytes;

--- a/include/hpdf_fontdef.h
+++ b/include/hpdf_fontdef.h
@@ -96,6 +96,9 @@ typedef struct _HPDF_FontDef_Rec {
 
     HPDF_INT16    ascent;
     HPDF_INT16    descent;
+    HPDF_INT16    line_gap;
+    HPDF_INT16    underline_position;
+    HPDF_INT16    underline_thickness;
     HPDF_UINT     flags;
     HPDF_Box      font_bbox;
     HPDF_INT16    italic_angle;
@@ -305,6 +308,15 @@ typedef struct _HPDF_TTFontDefAttr_Rec {
     HPDF_UINT16              fs_type;
     HPDF_BYTE                sfamilyclass[2];
     HPDF_BYTE                panose[10];
+
+    HPDF_INT16               typo_ascender;
+    HPDF_INT16               typo_descender;
+    HPDF_INT16               typo_linegap;
+    HPDF_UINT16              win_ascent;
+    HPDF_UINT16              win_descent;
+    HPDF_INT16               underline_position;
+    HPDF_INT16               underline_thickness;
+
     HPDF_UINT32              code_page_range1;
     HPDF_UINT32              code_page_range2;
 
@@ -312,6 +324,9 @@ typedef struct _HPDF_TTFontDefAttr_Rec {
 
     HPDF_BOOL                embedding;
     HPDF_BOOL                is_cidfont;
+
+    HPDF_UINT                cff_offset;
+    HPDF_UINT                cff_length;
 
     HPDF_Stream              stream;
 } HPDF_TTFontDefAttr_Rec;

--- a/include/hpdf_streams.h
+++ b/include/hpdf_streams.h
@@ -148,6 +148,14 @@ HPDF_Stream_WriteToStream  (HPDF_Stream   src,
                             HPDF_UINT     filter,
                             HPDF_Encrypt  e);
 
+HPDF_STATUS
+HPDF_Stream_WriteToStream2 (HPDF_Stream   src,
+                            HPDF_Stream   dst,
+                            HPDF_UINT     filter,
+                            HPDF_Encrypt  e,
+                            HPDF_UINT     offset,
+                            HPDF_UINT     length);
+
 
 HPDF_Stream
 HPDF_FileReader_New  (HPDF_MMgr   mmgr,


### PR DESCRIPTION
HPDF_LoadTTFontFromFile is now able to load OpenType fonts (*.otf; Adobe
type1 "CFF " table). The default implementation is PDF1.2 compatible.
You can activate the PDF1.6 implemention by setting HPDF_OPENTYPE_PDF16.

HPDF_FONT_FOURCE_BOLD/HPDF_FONT_ITALIC removed for TTF fonts otherwise some readers show it double bold which looks very ugly.

Strange code set back to the original code:
----
parray = attr->cmap.glyph_id_array;
    for (i = 0; i < 256; i++) {
        *parray = attr->cmap.glyph_id_array[i];
         ...
--- 
=> sets value to itself (?)