### PR TITLE
Implement HPDF_Image_LoadCcittImageFromMemory, allowing for quickly a…

### DIFF
--- a/include/hpdf_image.h
+++ b/include/hpdf_image.h
@@ -34,6 +34,15 @@ HPDF_Image_Load1BitImageFromMem  (HPDF_MMgr  mmgr,
                           HPDF_BOOL          top_is_first
                           );
 
+HPDF_Image
+HPDF_Image_LoadCcittImageFromMemory  (HPDF_MMgr mmgr,
+                          HPDF_Xref xref,
+                          const HPDF_BYTE* buffer,
+                          const HPDF_UINT buffer_size,
+                          const HPDF_INT32 width,
+                          const HPDF_INT32 height,
+                          HPDF_BOOL black_is1
+                          );
 
 #ifndef LIBHPDF_HAVE_NOPNGLIB
 


### PR DESCRIPTION
Implement `HPDF_Image_LoadCcittImageFromMemory`, allowing for quickly adding CCITT data without decoding and reencoding first.

Example (psuedo code) use:
```HPDF_BYTE *buffer = NULL;
TIFF* tif = TIFFOpen(file, "r");
HPDF_UINT32 tw, th, *sbc, strips;
HPDF_UINT16 pm, bps, comp;
size_t c = 0, o = 0;
tmsize_t tr;
HPDF_Image image;

TIFFGetFieldDefaulted(tif, TIFFTAG_IMAGEWIDTH, &tw, 0);
TIFFGetFieldDefaulted(tif, TIFFTAG_IMAGELENGTH, &th, 0);
TIFFGetFieldDefaulted(tif, TIFFTAG_BITSPERSAMPLE, &bps, 0);
TIFFGetFieldDefaulted(tif, TIFFTAG_PHOTOMETRIC, &pm, PHOTOMETRIC_MINISWHITE);
TIFFGetFieldDefaulted(tif, TIFFTAG_COMPRESSION, &comp, COMPRESSION_CCITTFAX4);
TIFFGetFieldDefaulted(tif, TIFFTAG_STRIPBYTECOUNTS, &sbc, NULL);

if(bp2 == 1 && (pm == PHOTOMETRIC_MINISBLACK || pm == PHOTOMETRIC_MINISWHITE) && comp == COMPRESSION_CCITTFAX4 && sbc != NULL) {
    strips = TIFFNumberOfStrips(tif);
    for(HPDF_UINT32* itr = sbc, end = sbc + strips; itr != end; ++itr)
        c += *itr;
    buffer = malloc(sizeof(HPDF_BYTE) * c);
    for(tstrip_t i = o; i < strips; ++i) {
        if((tr = TIFFReadRawStrip(tif, i, &buffer[0], sbc[i])) != sbc[i]) {
            free(buffer);
            return NULL;
        }
        o += sbc[i];
     }
     image = HPDF_Image_LoadCcittImageFromMemory(mmgr, xref, buffer, c, tw, th, pm != PHOTOMETRIC_MINISWHITE);
     free(buffer);
     return image;
}
...```