### PR TITLE
Fix config constant to match use in hpdf_mmgr.c

### DIFF
--- a/include/hpdf_conf.h
+++ b/include/hpdf_conf.h
@@ -78,8 +78,7 @@
 
 /* alignment size of memory-pool-object
  */
-#define HPDF_ALIGN_SIZ              sizeof int;
-
+#define HPDF_ALINMENT_SIZ              sizeof(int)
 
 #endif /* _HPDF_CONF_H */
 


### PR DESCRIPTION
There was a mismatch between the HPDF_ALINMENT_SIZ used in hpdf_mmgr.c and the one defined in hpdf_conf.h