### PR TITLE
Only included necessary char widths in generated PDF file to reduce file size

### DIFF
--- a/src/hpdf_font_cid.c
+++ b/src/hpdf_font_cid.c
@@ -442,17 +442,21 @@ CIDFontType2_BeforeWrite_Func  (HPDF_Dict obj)
 		    HPDF_UNICODE unicode = encoder_attr->unicode_map[i][j];
 		    HPDF_UINT16 gid = HPDF_TTFontDef_GetGlyphid (def,
 								 unicode);
-		    tmp_map[cid] = gid;
-		    if (max < cid)
-			max = cid;
+		    if (def_attr->glyph_tbl.flgs[gid]) {
+			tmp_map[cid] = gid;
+			if (max < cid)
+			    max = cid;
+		    }
 		}
 	    } else {
 		HPDF_UNICODE unicode = (i << 8) | j;
 		HPDF_UINT16 gid = HPDF_TTFontDef_GetGlyphid (def,
 							     unicode);
-		tmp_map[unicode] = gid;
-		if (max < unicode)
-		    max = unicode;
+		if (def_attr->glyph_tbl.flgs[gid]) {
+		    tmp_map[unicode] = gid;
+		    if (max < unicode)
+			max = unicode;
+		}
 	    }
 	}
     }

--- a/src/hpdf_font_cid.c
+++ b/src/hpdf_font_cid.c
@@ -473,7 +473,7 @@ CIDFontType2_BeforeWrite_Func  (HPDF_Dict obj)
         for (i = 0; i < max; i++, ptmp_map++) {
             HPDF_INT w = HPDF_TTFontDef_GetGidWidth (def, *ptmp_map);
 
-            if (w != dw) {
+            if (def_attr->glyph_tbl.flgs[*ptmp_map] && w != dw) {
                 if (!tmp_array) {
                     if (HPDF_Array_AddNumber (array, i) != HPDF_OK)
                         return HPDF_FAILD_TO_ALLOC_MEM;


### PR DESCRIPTION
This pull request reduces the file size for PDFs with embedded TrueType fonts.

a) creating the /W and /CIDToGIDMap attributes is now postponed to the before_write_fn where we already know which glyphs have been used,
b) the /W array now only includes char width for glyphs that have been used. This can save 10-30 kB for fonts with many glyphs.

I'm not very confident about the way errors are handled in the code that was moved from CIDFontType2_New to CIDFontType2_BeforeWrite_Func (I had changed return NULL to return HPDF_FAILD_TO_ALLOC_MEM). Maybe someone with more insight into libharu could fix this in case it's incorrect.