### PR TITLE
Improve small number writing in HPDF_FToA.

### DIFF
--- a/include/hpdf_consts.h
+++ b/include/hpdf_consts.h
@@ -32,7 +32,7 @@
 /* buffer size which is required when we convert to character string. */
 #define HPDF_TMP_BUF_SIZ            512
 #define HPDF_SHORT_BUF_SIZ          32
-#define HPDF_REAL_LEN               11
+#define HPDF_REAL_LEN               64
 #define HPDF_INT_LEN                11
 #define HPDF_TEXT_DEFAULT_LEN       256
 #define HPDF_UNICODE_HEADER_LEN     2

--- a/include/hpdf_types.h
+++ b/include/hpdf_types.h
@@ -45,6 +45,12 @@ typedef  signed int          HPDF_INT;
 typedef  unsigned int        HPDF_UINT;
 
 
+/*  64bit integer types
+ */
+typedef  signed long long    HPDF_INT64;
+typedef  unsigned long long  HPDF_UINT64;
+
+
 /*  32bit integer types
  */
 typedef  signed int          HPDF_INT32;


### PR DESCRIPTION
This was truncating all numbers at 1e-5, now it ensures that 5
significant figures will always be written for values > 1e-20.