### PR TITLE
Modify the error of text width in Traditional Chinese

### DIFF
--- a/src/hpdf_fontdef_cid.c
+++ b/src/hpdf_fontdef_cid.c
@@ -155,7 +155,7 @@ HPDF_CIDFontDef_AddWidth  (HPDF_FontDef            fontdef,
             return fontdef->error->error_no;
 
         w->cid = widths->cid;
-        w->width = widths->width;
+        w->width = (widths->width)*2;
 
         if ((ret = HPDF_List_Add (attr->widths, w)) != HPDF_OK) {
             HPDF_FreeMem (fontdef->mmgr, w);


### PR DESCRIPTION
When using the instruction "HPDF_UseCNTFonts()" to add the text like "由用未五伍民市今午依", the texts will half overlap on the previous text.Thus, I tried to fix it, and when I change the width, this problem can be solved.