### PR TITLE
Fix various typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -64,7 +64,7 @@ Version 2.2.0 (2010.10.12)
  - Fixed bug #10 (missing HPDF_LoadPngImageFromMem from win32/msvc/libhpdf.def).
  - Fixed bug #7 (HPDF_String_SetValue() is declared twice).
  - Fixed bug #6 (possible NULL dereference in HPDF_LoadPngImageFromFile2()).
- - Fixed bug #5 (possible NULL derefernce in HPDF_LoadRawImageFromFile()).
+ - Fixed bug #5 (possible NULL dereference in HPDF_LoadRawImageFromFile()).
  - Fixed bug #4 (possible NULL dereference in HPDF_AToI()).
  - Fixed bug #2 (Ruby binding: hpdf_insert_page has stray printf).
 
@@ -91,7 +91,7 @@ Version 2.0.7 (2006.11.05)
   HPDF_Image_GetSize2().
 
 Version 2.0.6 (2006.10.16)
- - Added opacity and blend-mode featurs.
+ - Added opacity and blend-mode features.
  - Added slide-show functions (contributed by Adrian Nelson). 
  - Added an interface for VB6 (contributed by Ko, Chi-Chih).
  - Fixed a bug that HPDF_MemStream_Rewrite() may cause segmentation fault.
@@ -108,7 +108,7 @@ Version 2.0.5 (2006.09.20)
  - Fixed a bug that causes program crash when using interlaced PNG images.
 
 Version 2.0.4 (2006.08.25)
- - Fixed a bug of the TrueType font feature related to composit glyph.
+ - Fixed a bug of the TrueType font feature related to composite glyph.
 
 Version 2.0.3 (2006.08.20)
  - Fixed a bug that HPDF_Page_TextRect() always returns 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,14 +84,14 @@ endif(BUILD_SHARED_LIBS)
 include(haru)
 include(summary)
 
-# check zlib availibility
+# check zlib availability
 find_package(ZLIB)
 if(ZLIB_FOUND)
   include_directories(${ZLIB_INCLUDE_DIR})
   set(ADDITIONAL_LIBRARIES ${ZLIB_LIBRARIES})
 endif(ZLIB_FOUND)
   
-# check png availibility
+# check png availability
 find_package(PNG)
 if(PNG_FOUND)
   include_directories(${PNG_INCLUDE_DIR})
@@ -127,7 +127,7 @@ set (LIBHPDF_PACKAGE_TARNAME "TODO")
 
 # Just set to 1, we'll assume they are always available.
 # If not, then someone will have to add some tests in here to correctly determine
-# the headers existance.
+# the headers existence.
 set (LIBHPDF_STDC_HEADERS 1)
 
 # Don't do anything with this, it doesn't seem to be used anywhere anyhow

--- a/README
+++ b/README
@@ -73,7 +73,7 @@ But when you use it as a shared-library, it can be used by many development
 languages which support shared libraries.
 So far, Haru provides bindings for Ruby, Delphi/Free Pascal, and C#.
 
-If you write bindings for other programing languages, please inform me!
+If you write bindings for other programming languages, please inform me!
 
 *
 * Runtime environment of programs using Haru

--- a/README_cmake
+++ b/README_cmake
@@ -11,7 +11,7 @@ CMake is available in most of Linux repositories and can
 be therefore easily installed. In Cygwin just use the 
 usual method with setup.exe to get the latest version of CMake.
 For Windows and Mac OS X go to http://www.cmake.org and 
-download the appropriate binary packge. Make sure that the
+download the appropriate binary package. Make sure that the
 bin directory of the extracted CMake package is in the 
 PATH environment variable. Check in the CLI with
 
@@ -58,7 +58,7 @@ where Make Generator is one of the following (most important listed)
   Visual Studio 6             = Generates Visual Studio 6 project files.
   Visual Studio 9 2008        = Generates Visual Studio 9 2008 project files.
 
-You get a complete list of all available generators for your platfrom
+You get a complete list of all available generators for your platform
 with "cmake --help". I'll go into details for one specific compiler toolset.
 The other generators work similar.
 
@@ -93,7 +93,7 @@ More options can be found here: http://www.cmake.org/Wiki/CMake_Useful_Variables
 X How does CMake find libraries
 ===============================
 CMake searches usually in the standard locations to find libraries, which
-works well on Linux und Mac OS X. This is not the case for Windows (where
+works well on Linux and Mac OS X. This is not the case for Windows (where
 there are simply no standard locations for libraries) or if you want to
 use a library at a non-standard location. You can help CMake to find
 libraries via two environment variables, e.g. for Windows:

--- a/demo/grid_sheet.c
+++ b/demo/grid_sheet.c
@@ -80,7 +80,7 @@ print_grid  (HPDF_Doc     pdf,
     }
 
 
-    /* Draw virtical lines */
+    /* Draw vertical lines */
     x = 0;
     while (x < width) {
         if (x % 10 == 0)
@@ -132,7 +132,7 @@ print_grid  (HPDF_Doc     pdf,
     }
 
 
-    /* Draw virtical text */
+    /* Draw vertical text */
     x = 0;
     while (x < width) {
         if (x % 50 == 0 && x > 0) {

--- a/demo/image_demo.c
+++ b/demo/image_demo.c
@@ -211,7 +211,7 @@ int main (int argc, char **argv)
 
     /* Rotating image */
     angle = 30;     /* rotation of 30 degrees. */
-    rad = angle / 180 * 3.141592; /* Calcurate the radian value. */
+    rad = angle / 180 * 3.141592; /* Calculate the radian value. */
 
     HPDF_Page_GSave (page);
 

--- a/demo/line_demo.c
+++ b/demo/line_demo.c
@@ -141,7 +141,7 @@ int main (int argc, char **argv)
 
     HPDF_Page_SetFontAndSize (page, font, 10);
 
-    /* Draw verious widths of lines. */
+    /* Draw various widths of lines. */
     HPDF_Page_SetLineWidth (page, 0);
     draw_line (page, 60, 770, "line width = 0");
 

--- a/demo/text_demo.c
+++ b/demo/text_demo.c
@@ -306,7 +306,7 @@ int main (int argc, char **argv)
      * Rotating text
      */
     angle1 = 30;                   /* A rotation of 30 degrees. */
-    rad1 = angle1 / 180 * 3.141592; /* Calcurate the radian value. */
+    rad1 = angle1 / 180 * 3.141592; /* Calculate the radian value. */
 
     show_description (page, 320, ypos - 60, "Rotating text");
     HPDF_Page_BeginText (page);

--- a/demo/type1/README
+++ b/demo/type1/README
@@ -3,7 +3,7 @@ type 1 font collection, repackaged for distribution with Ghostscript.
 
 Cyrillized free URW fonts.
 
-These fonts were made from the free URW fonts distributed with ghostcript.
+These fonts were made from the free URW fonts distributed with ghostscript.
 There are NO changes in the latin part of them (I hope).
 Cyrillic glyphs were added by copying suitable latin ones
 and painting oulines of unique cyrillic glyphs in same style as the others.

--- a/if/c#/demo/ImageDemo.cs
+++ b/if/c#/demo/ImageDemo.cs
@@ -135,7 +135,7 @@ public class ImageDemo {
 
             /* Rotating image */
             float angle = 30;     /* rotation of 30 degrees. */
-            float rad = angle / 180 * 3.141592f; /* Calcurate the radian value. */
+            float rad = angle / 180 * 3.141592f; /* Calculate the radian value. */
 
             page.GSave();
 

--- a/if/c#/demo/LineDemo.cs
+++ b/if/c#/demo/LineDemo.cs
@@ -80,7 +80,7 @@ public class LineDemo {
 
             page.SetFontAndSize(font, 10);
 
-            /* Draw verious widths of lines. */
+            /* Draw various widths of lines. */
             page.SetLineWidth(0);
             DrawLine(page, 60, 770, "line width = 0");
 

--- a/if/c#/demo/TextDemo.cs
+++ b/if/c#/demo/TextDemo.cs
@@ -230,7 +230,7 @@ public class TextDemo {
              * Rotating text
              */
             float angle1 = 30;                   /* A rotation of 30 degrees. */
-            float rad1 = angle1 / 180 * 3.141592f; /* Calcurate the radian value. */
+            float rad1 = angle1 / 180 * 3.141592f; /* Calculate the radian value. */
 
             ShowDescription(page, 320, ypos - 60, "Rotating text");
             page.BeginText();

--- a/if/delphi/LineDemo.dpr
+++ b/if/delphi/LineDemo.dpr
@@ -126,7 +126,7 @@ begin
 
     HPDF_Page_SetFontAndSize (page, font, 10);
 
-    {* Draw verious widths of lines. *}
+    {* Draw various widths of lines. *}
     HPDF_Page_SetLineWidth (page, 0);
     draw_line (page, 60, 770, 'line width := 0');
 

--- a/if/delphi/hpdf_consts.pas
+++ b/if/delphi/hpdf_consts.pas
@@ -62,7 +62,7 @@ const
 
   HPDF_BS_DEF_WIDTH = 1;
 
-{* defalt page-size *}
+{* default page-size *}
   HPDF_DEF_PAGE_WIDTH = 595.276;
   HPDF_DEF_PAGE_HEIGHT = 841.89;
 
@@ -529,7 +529,7 @@ const
 
 
 {*----------------------------------------------------------------------------*}
-{*----- Graphis mode ---------------------------------------------------------*}
+{*----- Graphics mode --------------------------------------------------------*}
 
   HPDF_GMODE_PAGE_DESCRIPTION = $0001;
   HPDF_GMODE_PATH_OBJECT = $0002;

--- a/if/delphi/hpdf_types.pas
+++ b/if/delphi/hpdf_types.pas
@@ -51,7 +51,7 @@ type
   HPDF_UINT8 = Byte;
 
 
-{*  8bit charactor types
+{*  8bit character types
  *}
   HPDF_CHAR = char;
 

--- a/if/freebasic/README.freebasic
+++ b/if/freebasic/README.freebasic
@@ -17,7 +17,7 @@ The steps to run the demonstration program are as follows:
    b) run with:     hpdftest.exe (on win32) or ./hpdftest (on linux)
 
 
-For more informations see: http://www.freebasic.net/forum/viewtopic.php?t=9014
+For more information see: http://www.freebasic.net/forum/viewtopic.php?t=9014
 
 
 NOTE:

--- a/if/python/History.txt
+++ b/if/python/History.txt
@@ -15,7 +15,7 @@ one, Traceback (most recent call last):
     c = HPDF_Page_GetRGBFill (page)
 ValueError: Procedure called with not enough arguments (4 bytes missing) or wrong calling convention
 
-Often, that msg happends when we load a Cdll with Windll method, vice versa. But why here?
+Often, that msg happens when we load a Cdll with Windll method, vice versa. But why here?
 
 two, if I comment out "c = HPDF_Page_GetRGBFill (page)", the yieled pdf has a unexpected layout
 

--- a/if/python/README.python
+++ b/if/python/README.python
@@ -2,7 +2,7 @@
 Pyharu is a pure python interface to haru(Haru Free PDF Library,
 http://libharu.org/). All of the C API is usable.
 No OO interface yet, but maybe in the feature, or you can write one by
-yourself and send me to be inculded in pyharu ;)
+yourself and send me to be included in pyharu ;)
 Pyharu runs on different python versions, and even in different OS
 without recompilation.
 
@@ -59,7 +59,7 @@ one, Traceback (most recent call last):
     c = HPDF_Page_GetRGBFill (page)
 ValueError: Procedure called with not enough arguments (4 bytes missing) or wrong calling convention
 
-Often, that msg happends when we load a Cdll with Windll method, vice versa. But why here?
+Often, that msg happens when we load a Cdll with Windll method, vice versa. But why here?
 
 two, if I comment out "c = HPDF_Page_GetRGBFill (page)", the yieled pdf has a unexpected layout
 
@@ -94,7 +94,7 @@ on your PC with the new one.
 
 8. What does the pyharu version number means?
 Well, I just use the version number of haru that I am using.
-That helps me to rember my development progress.
+That helps me to remember my development progress.
 
 9. License
 pyharu has a same license as haru, ie,  ZLIB/LIBPNG License.

--- a/if/python/demo/grid_sheet.py
+++ b/if/python/demo/grid_sheet.py
@@ -77,7 +77,7 @@ def print_grid  (pdf, page):
 
 
 
-    # Draw virtical lines
+    # Draw vertical lines
     x = 0
     while (x < width):
         if (x % 10 == 0):
@@ -124,7 +124,7 @@ def print_grid  (pdf, page):
         y += 5
 
 
-    # Draw virtical text
+    # Draw vertical text
     x = 0
     while (x < width):
         if (x % 50 == 0 and x > 0):

--- a/if/python/demo/image_demo.py
+++ b/if/python/demo/image_demo.py
@@ -159,7 +159,7 @@ def main ():
 
     # Rotating image
     angle = 30;     # rotation of 30 degrees.
-    rad = angle / 180 * 3.141592; # Calcurate the radian value.
+    rad = angle / 180 * 3.141592; # Calculate the radian value.
 
     HPDF_Page_GSave (page)
 

--- a/if/python/demo/line_demo.py
+++ b/if/python/demo/line_demo.py
@@ -112,7 +112,7 @@ def main ():
 
     HPDF_Page_SetFontAndSize (page, font, 10)
 
-    # Draw verious widths of lines.
+    # Draw various widths of lines.
     HPDF_Page_SetLineWidth (page, 0)
     draw_line (page, 60, 770, "line width = 0")
 

--- a/if/python/demo/text_demo.py
+++ b/if/python/demo/text_demo.py
@@ -271,7 +271,7 @@ def main ():
     # Rotating text
     #
     angle1 = 30;                   # A rotation of 30 degrees.
-    rad1 = angle1 / 180 * 3.141592; # Calcurate the radian value.
+    rad1 = angle1 / 180 * 3.141592; # Calculate the radian value.
 
     show_description (page, 320, ypos - 60, "Rotating text")
     HPDF_Page_BeginText (page)

--- a/if/python/hpdf_consts.py
+++ b/if/python/hpdf_consts.py
@@ -64,7 +64,7 @@ HPDF_DEF_PAGE_NUM          =1
 
 HPDF_BS_DEF_WIDTH          =1
 
-# defalt page-size
+# default page-size
 HPDF_DEF_PAGE_WIDTH        =595.276
 HPDF_DEF_PAGE_HEIGHT       =841.89
 
@@ -534,7 +534,7 @@ HPDF_LANG_ZU   ="zu"     # Zulu
 
 
 #----------------------------------------------------------------------------
-#----- Graphis mode ---------------------------------------------------------
+#----- Graphics mode --------------------------------------------------------
 
 HPDF_GMODE_PAGE_DESCRIPTION      =0x0001
 HPDF_GMODE_PATH_OBJECT           =0x0002

--- a/if/python/hpdf_errorcode.py
+++ b/if/python/hpdf_errorcode.py
@@ -59,7 +59,7 @@ error_detail={
 
 0x102B: 'An Invalid encoding name is specified.',
 
-0x102C: 'The lengh of the key of encryption is invalid.',
+0x102C: 'The length of the key of encryption is invalid.',
 
 0x102D: '1. An invalid font handle was set.\n2. Unsupported font format.',
 
@@ -78,7 +78,7 @@ error_detail={
 
 0x1037: 'An invalid page-handle was specified.',
 
-0x1038: 'An invalid pages-handle was specified. (internel error)',
+0x1038: 'An invalid pages-handle was specified. (internal error)',
 
 0x1039: 'An invalid value is set.',
 
@@ -106,7 +106,7 @@ error_detail={
 0x104D: 'Internal error. The consistency of the data was lost.',
 0x104E: 'The current font is not set.',
 
-0x104F: 'An invalid font-handle was spacified.',
+0x104F: 'An invalid font-handle was specified.',
 
 0x1050: 'An invalid font-size was set.',
 

--- a/if/ruby/demo/line_demo.rb
+++ b/if/ruby/demo/line_demo.rb
@@ -75,7 +75,7 @@ page.end_text
 
 page.set_font_and_size(font, 10)
 
-#Draw verious widths of lines.#
+#Draw various widths of lines.#
 page.set_line_width(0)
 draw_line(page, 60, 770, 'line width = 0')
 

--- a/if/vb.net/demo/ImageDemo.vb
+++ b/if/vb.net/demo/ImageDemo.vb
@@ -115,7 +115,7 @@ Module ImageDemo
 
             ' Rotating image 
             Dim angle As Single = 30                        ' rotation of 30 degrees.
-            Dim rad As Single = angle / 180 * 3.141592F     ' Calcurate the radian value.
+            Dim rad As Single = angle / 180 * 3.141592F     ' Calculate the radian value.
 
             page.GSave()
 

--- a/if/vb.net/demo/LineDemo.vb
+++ b/if/vb.net/demo/LineDemo.vb
@@ -62,7 +62,7 @@ Module LineDemo
 
             page.SetFontAndSize(font, 10)
 
-            ' Draw verious widths of lines.
+            ' Draw various widths of lines.
             page.SetLineWidth(0)
             DrawLine(page, 60, 770, "line width = 0")
 

--- a/if/vb6/hpdf_consts.bas
+++ b/if/vb6/hpdf_consts.bas
@@ -64,7 +64,7 @@ Public Const HPDF_DEF_PAGE_NUM = 1
 
 Public Const HPDF_BS_DEF_WIDTH = 1
 
-'/* defalt page-size */
+'/* default page-size */
 Public Const HPDF_DEF_PAGE_WIDTH = 595.276
 Public Const HPDF_DEF_PAGE_HEIGHT = 841.89
 
@@ -534,7 +534,7 @@ Public Const HPDF_LANG_ZU = "zu"       '/* Zulu */
 
 
 '/*----------------------------------------------------------------------------*/
-'/*----- Graphis mode ---------------------------------------------------------*/
+'/*----- Graphics mode --------------------------------------------------------*/
 
 Public Const HPDF_GMODE_PAGE_DESCRIPTION = &H1
 Public Const HPDF_GMODE_PATH_OBJECT = &H2

--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -975,7 +975,7 @@ HPDF_Font_MeasureText (HPDF_Font          font,
 
 
 /*--------------------------------------------------------------------------*/
-/*----- attachements -------------------------------------------------------*/
+/*----- attachments -------------------------------------------------------*/
 
 HPDF_EXPORT(HPDF_EmbeddedFile)
 HPDF_AttachFile  (HPDF_Doc    pdf,

--- a/include/hpdf_consts.h
+++ b/include/hpdf_consts.h
@@ -64,7 +64,7 @@
 
 #define HPDF_BS_DEF_WIDTH           1
 
-/* defalt page-size */
+/* default page-size */
 #define HPDF_DEF_PAGE_WIDTH         595.276F
 #define HPDF_DEF_PAGE_HEIGHT        841.89F
 
@@ -533,7 +533,7 @@
 
 
 /*----------------------------------------------------------------------------*/
-/*----- Graphis mode ---------------------------------------------------------*/
+/*----- Graphics mode --------------------------------------------------------*/
 
 #define   HPDF_GMODE_PAGE_DESCRIPTION       0x0001
 #define   HPDF_GMODE_PATH_OBJECT            0x0002

--- a/include/hpdf_font.h
+++ b/include/hpdf_font.h
@@ -72,7 +72,7 @@ typedef struct _HPDF_FontAttr_Rec {
     HPDF_Encoder                encoder;
 
     /* if the encoding-type is HPDF_ENCODER_TYPE_SINGLE_BYTE, the width of
-     * each charactors are cashed in 'widths'.
+     * each characters are cashed in 'widths'.
      * when HPDF_ENCODER_TYPE_DOUBLE_BYTE the width is calculate each time.
      */
     HPDF_INT16*                 widths;

--- a/include/hpdf_fontdef.h
+++ b/include/hpdf_fontdef.h
@@ -108,7 +108,7 @@ typedef struct _HPDF_FontDef_Rec {
     HPDF_UINT16   cap_height;
 
     /*  the initial value of descriptor entry is NULL.
-     *  when first font-object besed on the fontdef object is created,
+     *  when first font-object based on the fontdef object is created,
      *  the font-descriptor object is created and descriptor entry is set.
      */
     HPDF_Dict                descriptor;

--- a/src/hpdf_catalog.c
+++ b/src/hpdf_catalog.c
@@ -58,7 +58,7 @@ HPDF_Catalog_New  (HPDF_MMgr  mmgr,
     if (HPDF_Xref_Add (xref, catalog) != HPDF_OK)
         return NULL;
 
-    /* add requiered elements */
+    /* add required elements */
     ret += HPDF_Dict_AddName (catalog, "Type", "Catalog");
     ret += HPDF_Dict_Add (catalog, "Pages", HPDF_Pages_New (mmgr, NULL, xref));
 

--- a/src/hpdf_encoder.c
+++ b/src/hpdf_encoder.c
@@ -2577,7 +2577,7 @@ HPDF_CMapEncoder_InitAttr  (HPDF_Encoder  encoder)
 
     for (i = 0; i <= 255; i++) {
         for (j = 0; j <= 255; j++) {
-            /* undefined charactors are replaced to square */
+            /* undefined characters are replaced to square */
             encoder_attr->unicode_map[i][j] = 0x25A1;
         }
     }

--- a/src/hpdf_encoder_utf.c
+++ b/src/hpdf_encoder_utf.c
@@ -70,7 +70,7 @@ UTF8_Encoder_ByteType_Func  (HPDF_Encoder        encoder,
     // When HPDF_BYTE_TYPE_SINGLE is returned, the current byte is the
     //   CODE argument in call ToUnicode_Func
     // When HPDF_BYTE_TYPE_LEAD is returned, the current byte (msb) and the
-    //   next byte (lsb) is the CODE arguement in call ToUnicodeFunc
+    //   next byte (lsb) is the CODE argument in call ToUnicodeFunc
     // When HPDF_BYTE_TYPE_TRIAL is returned, the current byte is ignored
 
     HPDF_CMapEncoderAttr  encoder_attr;
@@ -133,7 +133,7 @@ UTF8_Encoder_ToUnicode_Func  (HPDF_Encoder   encoder,
                               HPDF_UINT16    code)
 {
     // Supposed to convert CODE to unicode.
-    // This function is allways called after ByteType_Func.
+    // This function is always called after ByteType_Func.
     // ByteType_Func recognizes the utf-8 bytes belonging to one character.
 
     HPDF_CMapEncoderAttr encoder_attr;

--- a/src/hpdf_font_tt.c
+++ b/src/hpdf_font_tt.c
@@ -113,7 +113,7 @@ HPDF_TTFont_New  (HPDF_MMgr        mmgr,
     /* singlebyte-font has a widths-array which is an array of 256 signed
      * short integer.
      * in the case of type1-font, widths-array for all letters is made in
-     * constructer. but in the case of true-type-font, the array is
+     * constructor. but in the case of true-type-font, the array is
      * initialized at 0, and set when the corresponding character was used
      * for the first time.
      */

--- a/src/hpdf_fontdef_tt.c
+++ b/src/hpdf_fontdef_tt.c
@@ -1254,7 +1254,7 @@ CheckCompositGryph  (HPDF_FontDef   fontdef,
         if (num_of_contours != -1)
             return HPDF_OK;
 
-        HPDF_PTRACE ((" CheckCompositGryph composit font gid=%u\n", gid));
+        HPDF_PTRACE ((" CheckCompositGryph composite font gid=%u\n", gid));
 
         if ((ret = HPDF_Stream_Seek (attr->stream, 8, HPDF_SEEK_CUR))
             != HPDF_OK)

--- a/src/hpdf_fontdef_type1.c
+++ b/src/hpdf_fontdef_type1.c
@@ -139,7 +139,7 @@ LoadAfm (HPDF_FontDef  fontdef,
 
     len = HPDF_TMP_BUF_SIZ;
 
-    /* chaeck AFM header */
+    /* check AFM header */
     if ((ret = HPDF_Stream_ReadLn (stream, buf, &len)) != HPDF_OK)
          return ret;
 
@@ -251,7 +251,7 @@ LoadAfm (HPDF_FontDef  fontdef,
         /* C default character code. */
         s = GetKeyword (buf, buf2, HPDF_LIMIT_MAX_NAME_LEN + 1);
         if (HPDF_StrCmp (buf2, "CX") == 0) {
-            /* not suppoted yet. */
+            /* not supported yet. */
             return HPDF_SetError (fontdef->error,
                     HPDF_INVALID_CHAR_MATRICS_DATA, 0);
         } else
@@ -401,7 +401,7 @@ HPDF_Type1FontDef_Load  (HPDF_MMgr         mmgr,
         return NULL;
     }
 
-    /* if font-data is specified, the font data is embeded */
+    /* if font-data is specified, the font data is embedded */
     if (font_data) {
         ret = LoadFontData (fontdef, font_data);
         if (ret != HPDF_OK) {

--- a/src/hpdf_image.c
+++ b/src/hpdf_image.c
@@ -183,7 +183,7 @@ HPDF_Image_LoadJpegImage  (HPDF_MMgr        mmgr,
 
     image->header.obj_class |= HPDF_OSUBCLASS_XOBJECT;
 
-    /* add requiered elements */
+    /* add required elements */
     image->filter = HPDF_STREAM_FILTER_DCT_DECODE;
     ret += HPDF_Dict_AddName (image, "Type", "XObject");
     ret += HPDF_Dict_AddName (image, "Subtype", "Image");

--- a/src/hpdf_pages.c
+++ b/src/hpdf_pages.c
@@ -110,7 +110,7 @@ HPDF_Pages_New  (HPDF_MMgr   mmgr,
     if (HPDF_Xref_Add (xref, pages) != HPDF_OK)
         return NULL;
 
-    /* add requiered elements */
+    /* add required elements */
     ret += HPDF_Dict_AddName (pages, "Type", "Pages");
     ret += HPDF_Dict_Add (pages, "Kids", HPDF_Array_New (pages->mmgr));
     ret += HPDF_Dict_Add (pages, "Count", HPDF_Number_New (pages->mmgr, 0));
@@ -343,7 +343,7 @@ HPDF_Page_New  (HPDF_MMgr   mmgr,
     attr->stream = attr->contents->stream;
     attr->xref = xref;
 
-    /* add requiered elements */
+    /* add required elements */
     ret += HPDF_Dict_AddName (page, "Type", "Page");
     ret += HPDF_Dict_Add (page, "MediaBox", HPDF_Box_Array_New (page->mmgr,
                 HPDF_ToBox (0, 0, (HPDF_INT16)(HPDF_DEF_PAGE_WIDTH), (HPDF_INT16)(HPDF_DEF_PAGE_HEIGHT))));
@@ -428,7 +428,7 @@ HPDF_Page_GetInheritableItem  (HPDF_Page          page,
     obj = HPDF_Dict_GetItem (page, key, obj_class);
 
     /* if resources of the object is NULL, search resources of parent
-     * pages recursivly
+     * pages recursively
      */
     if (!obj) {
         HPDF_Pages pages = HPDF_Dict_GetItem (page, "Parent", HPDF_OCLASS_DICT);
@@ -459,7 +459,7 @@ AddResource  (HPDF_Page  page)
     if (!resource)
         return HPDF_Error_GetCode (page->error);
 
-    /* althoth ProcSet-entry is obsolete, add it to resouce for
+    /* althoth ProcSet-entry is obsolete, add it to resource for
      * compatibility
      */
 
@@ -601,14 +601,14 @@ HPDF_Page_CreateXObjectFromImage(HPDF_Doc       pdf,
 
    fromxobject->header.obj_class |= HPDF_OSUBCLASS_XOBJECT;
 
-   /* add requiered elements */
+   /* add required elements */
    fromxobject->filter = HPDF_STREAM_FILTER_FLATE_DECODE;
 
    resource = HPDF_Dict_New (page->mmgr);
    if (!resource)
       return NULL;
 
-   /* althoth ProcSet-entry is obsolete, add it to resouce for
+   /* althoth ProcSet-entry is obsolete, add it to resource for
     * compatibility*/
 
    ret += HPDF_Dict_Add (fromxobject, "Resources", resource);
@@ -730,14 +730,14 @@ HPDF_Page_CreateXObjectAsWhiteRect  (HPDF_Doc   pdf,
 
    fromxobject->header.obj_class |= HPDF_OSUBCLASS_XOBJECT;
 
-   /* add requiered elements */
+   /* add required elements */
    fromxobject->filter = HPDF_STREAM_FILTER_FLATE_DECODE;
 
    resource = HPDF_Dict_New (page->mmgr);
    if (!resource)
       return NULL;
 
-   /* althoth ProcSet-entry is obsolete, add it to resouce for
+   /* althoth ProcSet-entry is obsolete, add it to resource for
     * compatibility*/
 
    ret += HPDF_Dict_Add (fromxobject, "Resources", resource);

--- a/src/hpdf_streams.c
+++ b/src/hpdf_streams.c
@@ -112,7 +112,7 @@ HPDF_FileStream_FreeFunc  (HPDF_Stream  stream);
  *  ptr : Pointer to a buffer to copy read data.
  *  size : Pointer to a variable which indecates buffer size.
  *
- *  HPDF_Stream_read returns HPDF_OK when success. On failer, it returns
+ *  HPDF_Stream_read returns HPDF_OK when success. On failure, it returns
  *  error-code returned by reading function of this stream.
  *
  */
@@ -141,7 +141,7 @@ HPDF_Stream_Read  (HPDF_Stream  stream,
  *  s : Pointer to a buffer to copy read data.
  *  size : buffer-size of s.
  *
- *  Read from stream until the buffer is exhausted or line-feed charactor is
+ *  Read from stream until the buffer is exhausted or line-feed character is
  *  read.
  *
  */
@@ -226,7 +226,7 @@ HPDF_Stream_ReadLn  (HPDF_Stream  stream,
  *  ptr : Pointer to a buffer to write.
  *  siz : The size of buffer to write.
  *
- *  HPDF_Stream_Write returns HPDF_OK when success. On failer, it returns
+ *  HPDF_Stream_Write returns HPDF_OK when success. On failure, it returns
  *  error-code returned by writing function of this stream.
  *
  */
@@ -836,7 +836,7 @@ HPDF_FileReader_ReadFunc  (HPDF_Stream  stream,
  *                     HPDF_SEEK_CUR : Relative to the current file position
  *                     HPDF_SEEK_END : Relative to the current end of file.
  *
- *  HPDF_FileReader_seek_fn returns HPDF_OK when successful. On failer
+ *  HPDF_FileReader_seek_fn returns HPDF_OK when successful. On failure
  *  the result is HPDF_FILE_IO_ERROR and HPDF_Error_GetCode2() returns the
  *  error which returned by file seeking function of platform.
  *
@@ -1375,7 +1375,7 @@ HPDF_MemStream_Rewrite  (HPDF_Stream  stream,
 /*
  *  HPDF_CallbackReader_new
  *
- *  Constractor for HPDF_CallbackReader.
+ *  Constructor for HPDF_CallbackReader.
  *
  *  mmgr : Pointer to a HPDF_MMgr object.
  *  read_fn : Pointer to a user function for reading data.
@@ -1421,7 +1421,7 @@ HPDF_CallbackReader_New  (HPDF_MMgr              mmgr,
 /*
  *  HPDF_CallbackWriter_new
  *
- *  Constractor for HPDF_CallbackWriter.
+ *  Constructor for HPDF_CallbackWriter.
  *
  *  mmgr : Pointer to a HPDF_MMgr object.
  *  read_fn : Pointer to a user function for writing data.

--- a/src/hpdf_utils.c
+++ b/src/hpdf_utils.c
@@ -31,7 +31,7 @@ HPDF_AToI  (const char  *s)
         return 0;
     }
 
-    /* increment pointer until the charactor of 's' is not
+    /* increment pointer until the character of 's' is not
      * white-space-charactor.
      */
     while (*s) {
@@ -67,7 +67,7 @@ HPDF_AToF  (const char  *s)
     HPDF_DOUBLE v;
     HPDF_INT tmp = 1;
 
-    /* increment pointer until the charactor of 's' is not
+    /* increment pointer until the character of 's' is not
      * white-space-charactor.
      */
     while (*s) {

--- a/src/hpdf_xref.c
+++ b/src/hpdf_xref.c
@@ -145,7 +145,7 @@ HPDF_Xref_Add  (HPDF_Xref  xref,
     }
 
     /* in the following, we have to dispose the object when an error is
-     * occured.
+     * occurred.
      */
 
     entry = (HPDF_XrefEntry)HPDF_GetMem (xref->mmgr,

--- a/win32/bcc32/libhpdf.rc
+++ b/win32/bcc32/libhpdf.rc
@@ -18,7 +18,7 @@ BLOCK "StringFileInfo"
 		VALUE "ProductName", ""
 		VALUE "ProductVersion", "2.1.0.0"
 		VALUE "Comments", ""
-		VALUE "Aditional Notes", ""
+		VALUE "Additional Notes", ""
 	}
 }
 

--- a/win32/libhpdf.rc.template
+++ b/win32/libhpdf.rc.template
@@ -18,7 +18,7 @@ BLOCK "StringFileInfo"
 		VALUE "ProductName", ""
 		VALUE "ProductVersion", "_VERSION2"
 		VALUE "Comments", ""
-		VALUE "Aditional Notes", ""
+		VALUE "Additional Notes", ""
 	}
 }
 

--- a/win32/mingw/libhpdf_cygwin.rc
+++ b/win32/mingw/libhpdf_cygwin.rc
@@ -18,7 +18,7 @@ BLOCK "StringFileInfo"
 		VALUE "ProductName", ""
 		VALUE "ProductVersion", "2.1.0.0"
 		VALUE "Comments", ""
-		VALUE "Aditional Notes", ""
+		VALUE "Additional Notes", ""
 	}
 }
 

--- a/win32/mingw/libhpdf_mingw.rc
+++ b/win32/mingw/libhpdf_mingw.rc
@@ -18,7 +18,7 @@ BLOCK "StringFileInfo"
 		VALUE "ProductName", ""
 		VALUE "ProductVersion", "2.1.0.0"
 		VALUE "Comments", ""
-		VALUE "Aditional Notes", ""
+		VALUE "Additional Notes", ""
 	}
 }
 

--- a/win32/msvc/libhpdf.rc
+++ b/win32/msvc/libhpdf.rc
@@ -18,7 +18,7 @@ BLOCK "StringFileInfo"
 		VALUE "ProductName", ""
 		VALUE "ProductVersion", "2.1.0.0"
 		VALUE "Comments", ""
-		VALUE "Aditional Notes", ""
+		VALUE "Additional Notes", ""
 	}
 }
 


### PR DESCRIPTION
Found via `codespell -q 3 -L appearence,ba,fo,ro,siz,suppliment,te`