### PR TITLE
Fix bad unicode in comment

### DIFF
--- a/include/hpdf_objects.h
+++ b/include/hpdf_objects.h
@@ -81,7 +81,7 @@ extern "C" {
  *  3       reserved
  *  4       shadow-object
  *  5-8     reserved
- *  9-32    object-idÅi0-8388607Åj
+ *  9-32    object-id
  *
  *  the real Object-ID is described "obj_id & 0x00FFFFFF"
  */


### PR DESCRIPTION
`hpdf_objects.h` has a stray 0x81 byte in a comment which is invalid UTF-8. This prevents compilation when running a compiler with strict encoding checks enabled, like MSVC with `/we4828`:

```
.\include\hpdf_objects.h(1): error C4828: The file contains a character starting at offset 0xb00 that is illegal in the current source character set (codepage 65001).
```