### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ But when you use it as shared-library, it can be used by many development
 languages which support shared library.
 So far, Haru provides bindings for Ruby, Delphi/Free Pascal and C#.
 
-If you write bindings for other programing languages, please notice me!
+If you write bindings for other programming languages, please notice me!
 
 
 # Runtime environment of programs using Haru

--- a/bindings/delphi/hpdf_types.pas
+++ b/bindings/delphi/hpdf_types.pas
@@ -83,7 +83,7 @@ type
   HPDF_STATUS = Cardinal;
 
 
-{*  charactor-code type (16bit)
+{*  character-code type (16bit)
  *}
   HPDF_CID = Word;
   HPDF_UNICODE = Word;

--- a/bindings/oberon-2/hpdf.ob2
+++ b/bindings/oberon-2/hpdf.ob2
@@ -78,7 +78,7 @@ TYPE
 
 
 (*
-  8bit charactor types
+  8bit character types
 *)
   HPDF_CHAR * = Windows.PSTR;
 
@@ -115,7 +115,7 @@ TYPE
 
 
 (*  
-  charactor-code type (16bit)
+  character-code type (16bit)
  *)
   HPDF_CID * = Windows.WCHAR;
   HPDF_UNICODE * = Windows.WCHAR;
@@ -539,7 +539,7 @@ CONST
 
   HPDF_BS_DEF_WIDTH            * = 1;
 
-(* defalt page-size *)
+(* default page-size *)
   HPDF_DEF_PAGE_WIDTH          * = 595.276;
   HPDF_DEF_PAGE_HEIGHT         * = 841.89;
 

--- a/bindings/python/hpdf_types.py
+++ b/bindings/python/hpdf_types.py
@@ -62,7 +62,7 @@ HPDF_BOOL=c_int
 HPDF_STATUS=c_ulong
 
 
-#  charactor-code type (16bit)
+#  character-code type (16bit)
 HPDF_CID=HPDF_UINT16
 HPDF_UNICODE=HPDF_UINT16
 

--- a/bindings/vb6/hpdf_types.bas
+++ b/bindings/vb6/hpdf_types.bas
@@ -68,7 +68,7 @@ Attribute VB_Name = "Module3"
 'typedef  unsigned long       HPDF_STATUS
 
 
-'/*  charactor-code type (16bit)
+'/*  character-code type (16bit)
 ' */
 'typedef  long16         HPDF_CID
 'typedef  long16         HPDF_UNICODE

--- a/include/hpdf_types.h
+++ b/include/hpdf_types.h
@@ -94,7 +94,7 @@ typedef  signed int          HPDF_BOOL;
 typedef  unsigned long       HPDF_STATUS;
 
 
-/*  charactor-code type (16bit)
+/*  character-code type (16bit)
  */
 typedef  HPDF_UINT16         HPDF_CID;
 typedef  HPDF_UINT16         HPDF_UNICODE;

--- a/src/hpdf_doc.c
+++ b/src/hpdf_doc.c
@@ -619,7 +619,7 @@ InternalSaveToStream  (HPDF_Doc      pdf,
     if ((ret = PrepareTrailer (pdf)) != HPDF_OK)
         return ret;
 
-    /* prepare encription */
+    /* prepare encryption */
     if (pdf->encrypt_on) {
         HPDF_Encrypt e= HPDF_EncryptDict_GetAttr (pdf->encrypt_dict);
 

--- a/src/hpdf_utils.c
+++ b/src/hpdf_utils.c
@@ -33,7 +33,7 @@ HPDF_AToI  (const char  *s)
     }
 
     /* increment pointer until the character of 's' is not
-     * white-space-charactor.
+     * white-space-character.
      */
     while (*s) {
         if (HPDF_IS_WHITE_SPACE(*s))
@@ -69,7 +69,7 @@ HPDF_AToF  (const char  *s)
     HPDF_INT tmp = 1;
 
     /* increment pointer until the character of 's' is not
-     * white-space-charactor.
+     * white-space-character.
      */
     while (*s) {
         if (HPDF_IS_WHITE_SPACE(*s))


### PR DESCRIPTION
Found via `codespell -q 3 -L appearence,ba,fo,ro,siz,suppliment,te`