### PR TITLE
Add copy hpdf_namedict.h at install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ set(
     include/hpdf_info.h
     include/hpdf_list.h
     include/hpdf_mmgr.h
+    include/hpdf_namedict.h
     include/hpdf_objects.h
     include/hpdf_outline.h
     include/hpdf_pages.h


### PR DESCRIPTION
I installed libharu with homebrew.
However, the project using libharu could not be built because the hpdf_namedict.h file was not found in the include directory.