### PR TITLE
Resolving an issue in CCITT compression when PDF compression is not set. 

### DIFF
--- a/src/hpdf_image_ccitt.c
+++ b/src/hpdf_image_ccitt.c
@@ -775,7 +775,7 @@ HPDF_Image_LoadRaw1BitImageFromMem  (HPDF_Doc           pdf,
     if (!image)
         HPDF_CheckError (&pdf->error);
 
-    if (pdf->compression_mode & HPDF_COMP_IMAGE)
+    if (HPDF_COMP_IMAGE)
 	{
 		image->filter = HPDF_STREAM_FILTER_CCITT_DECODE;
 		image->filterParams = HPDF_Dict_New(pdf->mmgr);


### PR DESCRIPTION
Compress 1-bit raw file with CCITT encoding even if it has no-compression flag was set.
This resolves the issue: https://github.com/libharu/libharu/issues/50

Update hpdf_image_ccitt.c