### PR TITLE
Fix compiler warnings and code duplications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ if (CMAKE_COMPILER_IS_GNUCC OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"))
    endif (LIBHPDF_ENABLE_EXCEPTIONS)
 endif ()
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
 # =======================================================================

--- a/demo/arc_demo.c
+++ b/demo/arc_demo.c
@@ -18,6 +18,7 @@
 #include <setjmp.h>
 #include "hpdf.h"
 #include "grid_sheet.h"
+#include "utils.h"
 
 jmp_buf env;
 

--- a/demo/attach.c
+++ b/demo/attach.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <setjmp.h>
 #include "hpdf.h"
+#include "utils.h"
 
 const char *text = "This PDF should have an attachment named basn3p08.png";
 

--- a/demo/character_map.c
+++ b/demo/character_map.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <setjmp.h>
 #include "hpdf.h"
+#include "utils.h"
 
 jmp_buf env;
 
@@ -232,7 +233,7 @@ main  (int      argc,
             buf[1] = j;
             buf[2] = 0;
 
-            btype = HPDF_Encoder_GetByteType (encoder, buf, 0);
+            btype = HPDF_Encoder_GetByteType (encoder, (char*)buf, 0);
             unicode = HPDF_Encoder_GetUnicode (encoder, code);
 
             if (btype == HPDF_BYTE_TYPE_LEAD &&
@@ -268,30 +269,18 @@ main  (int      argc,
             HPDF_Font title_font = HPDF_GetFont (pdf, "Helvetica", NULL);
             HPDF_Outline outline;
             HPDF_Destination dst;
-#ifdef __WIN32__
-            _snprintf (buf, 256, "0x%04X-0x%04X",
+            HPDF_snprintf (buf, 256, "0x%04X-0x%04X",
                     (unsigned int)(i * 256 + min_l),
                     (unsigned int)(i * 256 + max_l));
-#else
-            snprintf (buf, 256, "0x%04X-0x%04X",
-                    (unsigned int)(i * 256 + min_l),
-                    (unsigned int)(i * 256 + max_l));
-#endif
     outline = HPDF_CreateOutline (pdf, root, buf, NULL);
             dst = HPDF_Page_CreateDestination (page);
             HPDF_Outline_SetDestination(outline, dst);
 
             draw_page (pdf, page, title_font, font, (HPDF_BYTE)i, (HPDF_BYTE)min_l);
 
-#ifdef __WIN32__
-            _snprintf (buf, 256, "%s (%s) 0x%04X-0x%04X", argv[1], argv[2],
-                        (unsigned int)(i * 256 + min_l),
-                        (unsigned int)(i * 256 + max_l));
-#else
-            snprintf (buf, 256, "%s (%s) 0x%04X-0x%04X", argv[1], argv[2],
-                        (unsigned int)(i * 256 + min_l),
-                        (unsigned int)(i * 256 + max_l));
-#endif
+            HPDF_snprintf (buf, 256, "%s (%s) 0x%04X-0x%04X", argv[1], argv[2],
+                    (unsigned int)(i * 256 + min_l),
+                    (unsigned int)(i * 256 + max_l));
             HPDF_Page_SetFontAndSize (page, title_font, 10);
             HPDF_Page_BeginText (page);
             HPDF_Page_MoveTextPos (page, 40, HPDF_Page_GetHeight (page) - 35);

--- a/demo/chfont_demo.c
+++ b/demo/chfont_demo.c
@@ -54,7 +54,6 @@ main (int argc, char **argv)
     const char *fcp932_name;
     HPDF_Font fcp936;
     HPDF_Font fcp932;
-    int y;
 
     if (argc < 4) {
         printf ("chfont_demo <cp936-ttc-font-file-name> "

--- a/demo/encoding_list.c
+++ b/demo/encoding_list.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <setjmp.h>
 #include "hpdf.h"
+#include "utils.h"
 
 jmp_buf env;
 
@@ -38,7 +39,6 @@ static const int PAGE_WIDTH = 420;
 static const int PAGE_HEIGHT = 400;
 static const int CELL_WIDTH = 20;
 static const int CELL_HEIGHT = 20;
-static const int CELL_HEADER = 10;
 
 void
 draw_graph (HPDF_Page   page);
@@ -69,11 +69,7 @@ draw_graph (HPDF_Page   page)
         if (i > 0 && i <= 16) {
             HPDF_Page_BeginText (page);
             HPDF_Page_MoveTextPos (page, x + 5, PAGE_HEIGHT - 75);
-#ifdef __WIN32__
-            _snprintf(buf, 5, "%X", i - 1);
-#else
-            snprintf(buf, 5, "%X", i - 1);
-#endif
+            HPDF_snprintf(buf, 5, "%X", i - 1);
             HPDF_Page_ShowText (page, buf);
             HPDF_Page_EndText (page);
         }
@@ -90,11 +86,7 @@ draw_graph (HPDF_Page   page)
         if (i < 14) {
             HPDF_Page_BeginText (page);
             HPDF_Page_MoveTextPos (page, 45, y + 5);
-#ifdef __WIN32__
-            _snprintf(buf, 5, "%X", 15 - i);
-#else
-            snprintf(buf, 5, "%X", 15 - i);
-#endif
+            HPDF_snprintf(buf, 5, "%X", 15 - i);
             HPDF_Page_ShowText (page, buf);
             HPDF_Page_EndText (page);
         }

--- a/demo/grid_sheet.c
+++ b/demo/grid_sheet.c
@@ -18,6 +18,7 @@
 #include <setjmp.h>
 #include "hpdf.h"
 #include "grid_sheet.h"
+#include "utils.h"
 
 #ifdef STAND_ALONE
 jmp_buf env;
@@ -119,11 +120,7 @@ print_grid  (HPDF_Doc     pdf,
 
             HPDF_Page_BeginText (page);
             HPDF_Page_MoveTextPos (page, 5, y - 2);
-#ifdef __WIN32__
-            _snprintf (buf, 12, "%u", y);
-#else
-            snprintf (buf, 12, "%u", y);
-#endif
+            HPDF_snprintf (buf, 12, "%u", y);
             HPDF_Page_ShowText (page, buf);
             HPDF_Page_EndText (page);
         }
@@ -140,11 +137,7 @@ print_grid  (HPDF_Doc     pdf,
 
             HPDF_Page_BeginText (page);
             HPDF_Page_MoveTextPos (page, x, 5);
-#ifdef __WIN32__
-            _snprintf (buf, 12, "%u", x);
-#else
-            snprintf (buf, 12, "%u", x);
-#endif
+            HPDF_snprintf (buf, 12, "%u", x);
             HPDF_Page_ShowText (page, buf);
             HPDF_Page_EndText (page);
 

--- a/demo/image_demo.c
+++ b/demo/image_demo.c
@@ -18,6 +18,7 @@
 #include <math.h>
 #include <setjmp.h>
 #include "hpdf.h"
+#include "utils.h"
 
 #ifndef HPDF_NOPNGLIB
 
@@ -56,11 +57,7 @@ show_description (HPDF_Page    page,
 
     HPDF_Page_BeginText (page);
 
-#ifdef __WIN32__
-    _snprintf(buf, 255, "(x=%d,y=%d)", (int)x, (int)y);
-#else
-    snprintf(buf, 255, "(x=%d,y=%d)", (int)x, (int)y);
-#endif /* __WIN32__ */
+    HPDF_snprintf(buf, 255, "(x=%d,y=%d)", (int)x, (int)y);
     HPDF_Page_MoveTextPos (page, x - HPDF_Page_TextWidth (page, buf) - 5,
             y - 10);
     HPDF_Page_ShowText (page, buf);

--- a/demo/line_demo.c
+++ b/demo/line_demo.c
@@ -89,9 +89,9 @@ int main (int argc, char **argv)
     HPDF_Page page;
     char fname[256];
 
-    const HPDF_UINT16 DASH_MODE1[] = {3};
-    const HPDF_UINT16 DASH_MODE2[] = {3, 7};
-    const HPDF_UINT16 DASH_MODE3[] = {8, 7, 2, 7};
+    const HPDF_REAL DASH_MODE1[] = {3};
+    const HPDF_REAL DASH_MODE2[] = {3, 7};
+    const HPDF_REAL DASH_MODE3[] = {8, 7, 2, 7};
 
     double x;
     double y;

--- a/demo/link_annotation.c
+++ b/demo/link_annotation.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <setjmp.h>
 #include "hpdf.h"
+#include "utils.h"
 
 jmp_buf env;
 
@@ -47,11 +48,7 @@ print_page  (HPDF_Page page, HPDF_Font font, int page_num)
 
     HPDF_Page_BeginText (page);
     HPDF_Page_MoveTextPos (page, 50, 150);
-#ifdef __WIN32__
-    _snprintf(buf, 50, "Page:%d", page_num);
-#else
-    snprintf(buf, 50, "Page:%d", page_num);
-#endif
+    HPDF_snprintf(buf, 50, "Page:%d", page_num);
     HPDF_Page_ShowText (page, buf);
     HPDF_Page_EndText (page);
 }

--- a/demo/outline_demo.c
+++ b/demo/outline_demo.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <setjmp.h>
 #include "hpdf.h"
+#include "utils.h"
 
 jmp_buf env;
 
@@ -34,7 +35,6 @@ error_handler  (HPDF_STATUS   error_no,
     longjmp(env, 1);
 }
 
-
 void
 print_page  (HPDF_Page   page,  int page_num)
 {
@@ -45,11 +45,7 @@ print_page  (HPDF_Page   page,  int page_num)
 
     HPDF_Page_BeginText (page);
     HPDF_Page_MoveTextPos (page, 30, 740);
-#ifdef __WIN32__
-    _snprintf(buf, 50, "Page:%d", page_num);
-#else
-    snprintf(buf, 50, "Page:%d", page_num);
-#endif
+    HPDF_snprintf(buf, 50, "Page:%d", page_num);
     HPDF_Page_ShowText (page, buf);
     HPDF_Page_EndText (page);
 }
@@ -105,8 +101,13 @@ int main(int argc, char **argv)
     outline[1] = HPDF_CreateOutline (pdf, root, "page2", NULL);
 
     /* create outline with test which is ISO8859-2 encoding */
-    outline[2] = HPDF_CreateOutline (pdf, root, "ISO8859-2 text гдежзий",
-                    HPDF_GetEncoder (pdf, "ISO8859-2"));
+
+    const char *outline_text = "ISO8859-2 text %s";
+    char buf[50] = {0};
+
+    HPDF_snprintf(buf, 50, outline_text, iso8859_2_text);
+
+    outline[2] = HPDF_CreateOutline (pdf, root, buf, HPDF_GetEncoder (pdf, "ISO8859-2"));
 
     /* create destination objects on each pages
      * and link it to outline items.

--- a/demo/outline_demo_jp.c
+++ b/demo/outline_demo_jp.c
@@ -45,11 +45,7 @@ print_page  (HPDF_Page   page,  int page_num)
 
     HPDF_Page_BeginText (page);
     HPDF_Page_MoveTextPos (page, 50, 250);
-#ifdef __WIN32__
-    _snprintf(buf, 50, "Page:%d", page_num);
-#else
-    snprintf(buf, 50, "Page:%d", page_num);
-#endif
+    HPDF_snprintf(buf, 50, "Page:%d", page_num);
     HPDF_Page_ShowText (page, buf);
     HPDF_Page_EndText (page);
 }

--- a/demo/slide_show_demo.c
+++ b/demo/slide_show_demo.c
@@ -39,9 +39,9 @@ void
 print_page  (HPDF_Page  page, const char *caption, HPDF_Font font, 
     HPDF_TransitionStyle style, HPDF_Page prev, HPDF_Page next)
 {
-    float r = (float)rand() / RAND_MAX;
-    float g = (float)rand() / RAND_MAX;
-    float b = (float)rand() / RAND_MAX;
+    float r = (float)rand() / (float)RAND_MAX;
+    float g = (float)rand() / (float)RAND_MAX;
+    float b = (float)rand() / (float)RAND_MAX;
     HPDF_Rect rect;
     HPDF_Destination dst;
     HPDF_Annotation annot;

--- a/demo/text_annotation.c
+++ b/demo/text_annotation.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <setjmp.h>
 #include "hpdf.h"
+#include "utils.h"
 
 jmp_buf env;
 
@@ -33,7 +34,6 @@ error_handler  (HPDF_STATUS   error_no,
                 (HPDF_UINT)detail_no);
     longjmp(env, 1);
 }
-
 
 int main(int argc, char **argv)
 {
@@ -115,8 +115,12 @@ int main(int argc, char **argv)
 
     encoding = HPDF_GetEncoder (pdf, "ISO8859-2");
 
+    const char *annotation_text = "Annotation with ISO8859 text %s";
+    char buf[50] = {0};
+    HPDF_snprintf(buf, 50, annotation_text, iso8859_2_text);
+
     HPDF_Page_CreateTextAnnot (page, rect8,
-                "Annotation with ISO8859 text гдежзий", encoding);
+                buf, encoding);
 
     HPDF_Page_SetFontAndSize (page, font, 11);
 

--- a/demo/text_demo.c
+++ b/demo/text_demo.c
@@ -19,6 +19,7 @@
 #include <setjmp.h>
 #include "hpdf.h"
 #include "grid_sheet.h"
+#include "utils.h"
 
 jmp_buf env;
 
@@ -173,11 +174,7 @@ int main (int argc, char **argv)
         /* print the description. */
         HPDF_Page_MoveTextPos (page, 0, -10);
         HPDF_Page_SetFontAndSize(page, font, 8);
-        #ifdef __WIN32__
-        _snprintf(buf, 50, "Fontsize=%.0f", fsize);
-        #else
-        snprintf(buf, 50, "Fontsize=%.0f", fsize);
-        #endif
+        HPDF_snprintf(buf, 50, "Fontsize=%.0f", fsize);
         HPDF_Page_ShowText (page, buf);
 
         fsize *= 1.5;

--- a/demo/text_demo2.c
+++ b/demo/text_demo2.c
@@ -19,6 +19,7 @@
 #include <setjmp.h>
 #include "hpdf.h"
 #include "grid_sheet.h"
+#include "utils.h"
 
 jmp_buf env;
 
@@ -45,11 +46,7 @@ PrintText(HPDF_Page page)
     HPDF_Point pos = HPDF_Page_GetCurrentTextPos (page);
 
     no++;
-    #ifdef __WIN32__
-    _snprintf (buf, 512, ".[%d]%0.2f %0.2f", no, pos.x, pos.y);
-    #else
-    snprintf (buf, 512, ".[%d]%0.2f %0.2f", no, pos.x, pos.y);
-    #endif
+    HPDF_snprintf (buf, 512, ".[%d]%0.2f %0.2f", no, pos.x, pos.y);
     HPDF_Page_ShowText(page, buf);
 }
 
@@ -65,7 +62,6 @@ main (int argc, char **argv)
     float angle2;
     float rad1;
     float rad2;
-    HPDF_REAL page_height;
     HPDF_Rect rect;
     int i;
 
@@ -90,8 +86,6 @@ main (int argc, char **argv)
     HPDF_Page_SetSize (page, HPDF_PAGE_SIZE_A5, HPDF_PAGE_PORTRAIT);
 
     print_grid  (pdf, page);
-
-    page_height = HPDF_Page_GetHeight (page);
 
     font = HPDF_GetFont (pdf, "Helvetica", NULL);
     HPDF_Page_SetTextLeading (page, 20);

--- a/demo/utils.h
+++ b/demo/utils.h
@@ -1,0 +1,31 @@
+/*
+ * << Haru Free PDF Library 2.0.0 >> -- utils.h
+ *
+ * Copyright (c) 1999-2006 Takeshi Kanno <takeshi_kanno@est.hi-ho.ne.jp>
+ * Copyright (c) 2007-2009 Antony Dovgal et al.
+ * Copyright (c) 2023 Dmitry Solomennikov
+ *
+ * Permission to use, copy, modify, distribute and sell this software
+ * and its documentation for any purpose is hereby granted without fee,
+ * provided that the above copyright notice appear in all copies and
+ * that both that copyright notice and this permission notice appear
+ * in supporting documentation.
+ * It is provided "as is" without express or implied warranty.
+ *
+ */
+
+#ifndef __UTILS_H
+#define __UTILS_H
+
+#include "hpdf.h"
+
+#if defined(__WIN32__) || defined(__WIN64__)
+#  define HPDF_snprintf _snprintf
+#else
+#  define HPDF_snprintf  snprintf
+#endif // defined(__WIN32__) || defined(__WIN64__)
+
+// Same as ÓÔŐÖ×ŘŮ, but in ISO8859-2 codepage
+static const char iso8859_2_text[7] = {0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9};
+
+#endif /* __UTILS_H */

--- a/src/hpdf_annotation.c
+++ b/src/hpdf_annotation.c
@@ -37,9 +37,9 @@ static const char * const HPDF_ANNOT_TYPE_NAMES[] = {
                                         "Popup",
                                         "3D",
                                         "Squiggly",
-					"Line",
-					"Projection",
-					"Widget"
+                                        "Line",
+                                        "Projection",
+                                        "Widget"
                                         };
 
 static const char * const HPDF_ANNOT_ICON_NAMES_NAMES[] = {
@@ -318,7 +318,7 @@ HPDF_LinkAnnot_SetJavaScript(HPDF_Annotation annot, HPDF_JavaScript javascript)
     if (ret != HPDF_OK)
         return HPDF_CheckError (annot->error);
 
-	ret += HPDF_Dict_Add (action, "JS", javascript);
+    ret += HPDF_Dict_Add (action, "JS", javascript);
     ret += HPDF_Dict_AddName (action, "S", "JavaScript");
 
     if (ret != HPDF_OK)
@@ -889,12 +889,12 @@ HPDF_PopupAnnot_New (HPDF_MMgr         mmgr,
 }
 
 HPDF_Annotation
-HPDF_StampAnnot_New (HPDF_MMgr         mmgr,
-                     HPDF_Xref         xref,
-                     HPDF_Rect         rect,
-                     HPDF_StampAnnotName name,
-                     const char*       text,
-                     HPDF_Encoder       encoder)
+HPDF_StampAnnot_New (HPDF_MMgr             mmgr,
+                     HPDF_Xref             xref,
+                     HPDF_Rect             rect,
+                     HPDF_StampAnnotName   name,
+                     const char           *text,
+                     HPDF_Encoder          encoder)
 {
     HPDF_Annotation annot;
     HPDF_String s;
@@ -919,27 +919,27 @@ HPDF_StampAnnot_New (HPDF_MMgr         mmgr,
 
 HPDF_Annotation
 HPDF_ProjectionAnnot_New(HPDF_MMgr         mmgr,
-						 HPDF_Xref         xref,
-						 HPDF_Rect         rect,
-						 const char*       text,
-						 HPDF_Encoder       encoder)
+                         HPDF_Xref         xref,
+                         HPDF_Rect         rect,
+                         const char       *text,
+                         HPDF_Encoder      encoder)
 {
-	HPDF_Annotation annot;
-	HPDF_String s;
-	HPDF_PTRACE((" HPDF_StampAnnot_New\n"));
+    HPDF_Annotation annot;
+    HPDF_String s;
+    HPDF_PTRACE((" HPDF_StampAnnot_New\n"));
+    annot = HPDF_Annotation_New (mmgr, xref, HPDF_ANNOT_PROJECTION, rect);
 
-	annot = HPDF_Annotation_New (mmgr, xref, HPDF_ANNOT_PROJECTION, rect);
-	if (!annot)
-		return NULL;
+    if (!annot)
+        return NULL;
 
-	s = HPDF_String_New (mmgr, text, encoder);
-	if (!s)
-		return NULL;
+    s = HPDF_String_New (mmgr, text, encoder);
+    if (!s)
+        return NULL;
 
-	if (HPDF_Dict_Add (annot, "Contents", s) != HPDF_OK)
-		return NULL;
+    if (HPDF_Dict_Add (annot, "Contents", s) != HPDF_OK)
+        return NULL;
 
-	return annot;
+    return annot;
 }
 
 
@@ -1007,7 +1007,7 @@ HPDF_MarkupAnnot_SetRectDiff (HPDF_Annotation  annot, HPDF_Rect  rect) /* RD ent
     HPDF_PTRACE((" HPDF_MarkupAnnot_SetRectDiff\n"));
 
     array = HPDF_Array_New ( annot->mmgr);
-    if ( !array)
+    if (!array)
         return HPDF_Error_GetCode ( annot->error);
 
     if ((ret = HPDF_Dict_Add ( annot, "RD", array)) != HPDF_OK)
@@ -1217,9 +1217,7 @@ HPDF_LineAnnot_SetCaption (HPDF_Annotation annot, HPDF_BOOL showCaption, HPDF_Li
 HPDF_EXPORT(HPDF_STATUS)
 HPDF_ProjectionAnnot_SetExData(HPDF_Annotation annot, HPDF_ExData exdata)
 {
-	HPDF_STATUS ret = HPDF_OK;
+    HPDF_STATUS ret = HPDF_Dict_Add(annot, "ExData", exdata);
 
-	ret = HPDF_Dict_Add(annot, "ExData", exdata);
-
-	return ret;
+    return ret;
 }

--- a/src/hpdf_doc_png.c
+++ b/src/hpdf_doc_png.c
@@ -186,4 +186,4 @@ LoadPngImageFromStream (HPDF_Doc      pdf,
     return NULL;
 }
 
-#endif /* LIBHPDF_HAVE_PNGLIB */
+#endif /* LIBHPDF_HAVE_LIBPNG */

--- a/src/hpdf_font_cid.c
+++ b/src/hpdf_font_cid.c
@@ -677,7 +677,8 @@ MeasureText  (HPDF_Font          font,
     HPDF_UINT tmp_len = 0;
     HPDF_UINT i;
     HPDF_FontAttr attr = (HPDF_FontAttr)font->attr;
-    HPDF_ByteType last_btype = HPDF_BYTE_TYPE_TRAIL;
+    // Comment to make compiler happy
+    // HPDF_ByteType last_btype = HPDF_BYTE_TYPE_TRAIL;
     HPDF_Encoder encoder = attr->encoder;
     HPDF_ParseText_Rec  parse_state;
     HPDF_INT dw2;
@@ -724,8 +725,9 @@ MeasureText  (HPDF_Font          font,
                 tmp_len = i + 1;
                 if (real_width)
                     *real_width = w;
-            } /* else
-			//Commenting this out fixes problem with HPDF_Text_Rect() splitting the words
+            }
+            /* else
+            // Commenting this out fixes problem with HPDF_Text_Rect() splitting the words
             if (last_btype == HPDF_BYTE_TYPE_TRAIL ||
                     (btype == HPDF_BYTE_TYPE_LEAD &&
                     last_btype == HPDF_BYTE_TYPE_SINGLE)) {
@@ -734,7 +736,8 @@ MeasureText  (HPDF_Font          font,
                     if (real_width)
                         *real_width = w;
                 }
-            }*/
+            }
+            */
         }
 
         if (HPDF_IS_WHITE_SPACE(b)) {
@@ -767,10 +770,13 @@ MeasureText  (HPDF_Font          font,
         if (w > width || b == 0x0A)
             return tmp_len;
 
+        /*
+        // Commented alongside of previous commented items
         if (HPDF_IS_WHITE_SPACE(b))
             last_btype = HPDF_BYTE_TYPE_TRAIL;
         else
             last_btype = btype;
+        */
     }
 
     /* all of text can be put in the specified width */

--- a/src/hpdf_image_png.c
+++ b/src/hpdf_image_png.c
@@ -708,4 +708,4 @@ PngAfterWrite  (HPDF_Dict obj)
 }
 
 
-#endif /* LIBHPDF_HAVE_PNGLIB */
+#endif /* LIBHPDF_HAVE_LIBPNG */

--- a/src/hpdf_pages.c
+++ b/src/hpdf_pages.c
@@ -587,7 +587,7 @@ HPDF_Page_CreateXObjectFromImage(HPDF_Doc       pdf,
     HPDF_Dict resource;
     HPDF_Dict fromxobject;
     HPDF_Dict xobject;
-    HPDF_STATUS ret = HPDF_OK;
+    HPDF_STATUS ret;
     HPDF_Array procset;
     HPDF_REAL tmp;
     HPDF_Array array1;
@@ -608,10 +608,11 @@ HPDF_Page_CreateXObjectFromImage(HPDF_Doc       pdf,
    if (!resource)
       return NULL;
 
-   /* althoth ProcSet-entry is obsolete, add it to resource for
-    * compatibility*/
+   /* Although ProcSet entry is obsolete, add it to resource
+    * for compatibility.
+    */
 
-   ret += HPDF_Dict_Add (fromxobject, "Resources", resource);
+   ret = HPDF_Dict_Add (fromxobject, "Resources", resource);
 
    procset = HPDF_Array_New (page->mmgr);
    if (!procset)
@@ -620,6 +621,9 @@ HPDF_Page_CreateXObjectFromImage(HPDF_Doc       pdf,
    ret += HPDF_Dict_Add (resource, "ProcSet", procset);
    ret += HPDF_Array_Add (procset, HPDF_Name_New (page->mmgr, "PDF"));
    ret += HPDF_Array_Add (procset, HPDF_Name_New (page->mmgr, "ImageC"));
+
+   if (ret != HPDF_OK)
+       return NULL;
 
     xobject = HPDF_Dict_New (page->mmgr);
     if (!xobject)
@@ -716,7 +720,7 @@ HPDF_Page_CreateXObjectAsWhiteRect  (HPDF_Doc   pdf,
     HPDF_Dict resource;
     HPDF_Dict fromxobject;
     HPDF_Dict xobject;
-    HPDF_STATUS ret = HPDF_OK;
+    HPDF_STATUS ret;
     HPDF_Array procset;
     HPDF_REAL tmp;
     HPDF_Array array1;
@@ -737,10 +741,11 @@ HPDF_Page_CreateXObjectAsWhiteRect  (HPDF_Doc   pdf,
    if (!resource)
       return NULL;
 
-   /* althoth ProcSet-entry is obsolete, add it to resource for
-    * compatibility*/
+   /* Although ProcSet entry is obsolete, add it to resource
+    * for compatibility
+    */
 
-   ret += HPDF_Dict_Add (fromxobject, "Resources", resource);
+   ret = HPDF_Dict_Add (fromxobject, "Resources", resource);
 
    procset = HPDF_Array_New (page->mmgr);
    if (!procset)
@@ -749,6 +754,9 @@ HPDF_Page_CreateXObjectAsWhiteRect  (HPDF_Doc   pdf,
    ret += HPDF_Dict_Add (resource, "ProcSet", procset);
    ret += HPDF_Array_Add (procset, HPDF_Name_New (page->mmgr, "PDF"));
    ret += HPDF_Array_Add (procset, HPDF_Name_New (page->mmgr, "ImageC"));
+
+   if (ret != HPDF_OK)
+       return NULL;
 
     xobject = HPDF_Dict_New (page->mmgr);
     if (!xobject)

--- a/src/hpdf_pdfa.c
+++ b/src/hpdf_pdfa.c
@@ -151,8 +151,6 @@ HPDF_PDFA_SetPDFAConformance (HPDF_Doc pdf,HPDF_PDFAType pdfatype)
     const char *pdf_Keywords    = NULL;
     const char *pdf_Producer    = NULL;
 
-    const char *info = NULL;
-
     if (!HPDF_HasDoc(pdf)) {
       return HPDF_INVALID_DOCUMENT;
     }

--- a/src/hpdf_shading.c
+++ b/src/hpdf_shading.c
@@ -29,9 +29,10 @@ typedef struct _RGBVertex
   HPDF_UINT8 RGB[3];
 } RGBVertex;
 
-static const char *COL_CMYK = "DeviceCMYK";
 static const char *COL_RGB = "DeviceRGB";
-static const char *COL_GRAY = "DeviceGray";
+// TODO Add shading for these color spaces
+//static const char *COL_CMYK = "DeviceCMYK";
+//static const char *COL_GRAY = "DeviceGray";
 
 /* bbox is filled with xMin, xMax, yMin, yMax */
 static HPDF_BOOL _GetDecodeArrayVertexValues(HPDF_Shading shading,


### PR DESCRIPTION
Add `-Wall` compiler flag to build and fixed all found compilation warnings.
This gives clean build both on Linux and MacOS.
Move out `snprintf` and `_snprintf` difference to separate header file to avoid code duplication.