### PR TITLE
PDF/A: fix to export `HPDF_PDFA_SetPDFAConformance` from DLL

### DIFF
--- a/include/hpdf_pdfa.h
+++ b/include/hpdf_pdfa.h
@@ -30,10 +30,10 @@ extern "C" {
 HPDF_STATUS
 HPDF_PDFA_AppendOutputIntents(HPDF_Doc pdf, const char *iccname, HPDF_Dict iccdict);
 
-HPDF_STATUS
+HPDF_EXPORT(HPDF_STATUS)
 HPDF_PDFA_SetPDFAConformance (HPDF_Doc pdf,
-			      HPDF_PDFAType pdfatype);
-			      
+                              HPDF_PDFAType pdfatype);
+
 HPDF_STATUS
 HPDF_PDFA_GenerateID(HPDF_Doc);
 #ifdef __cplusplus

--- a/src/hpdf_pdfa.c
+++ b/src/hpdf_pdfa.c
@@ -134,7 +134,7 @@ HPDF_STATUS ConvertDateToXMDate(HPDF_Stream stream, const char *pDate)
 
 /* Write XMP Metadata for PDF/A */
 
-HPDF_STATUS
+HPDF_EXPORT(HPDF_STATUS)
 HPDF_PDFA_SetPDFAConformance (HPDF_Doc pdf,HPDF_PDFAType pdfatype)
 {
     HPDF_OutputIntent xmp;


### PR DESCRIPTION
`HPDF_PDFA_SetPDFAConformance()` is meant to be public API and libharu itself doesn't call it. Before this patch, user code could not call it from `libharu.dll` on Windows, because its symbol wasn't exported. Fix this by exporting it like all other public APIs.

Also fix tabs and line-ending whitespace around the declaration.

Follow-up to 759f093de39650948b98a5cc9caac9378ec40817