### PR TITLE
Fix build with UNITY_BUILD 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,10 @@ set(
     hpdf_encoder_utf.c
 )
 
+set_property(SOURCE hpdf_shading.c hpdf_font_tt.c hpdf_fontdef_tt.c
+  PROPERTY
+    SKIP_UNITY_BUILD_INCLUSION ON)
+
 # =======================================================================
 # create hpdf library
 # =======================================================================


### PR DESCRIPTION
Fixes build with UNITY_BUILD by excluding sources with redefinitions, solves compilation from vtk:
https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html