### PR TITLE
Support for OpenType fonts

### DIFF
--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -959,6 +959,18 @@ HPDF_EXPORT(HPDF_INT)
 HPDF_Font_GetDescent  (HPDF_Font  font);
 
 
+HPDF_EXPORT(HPDF_INT)
+HPDF_Font_GetLeading  (HPDF_Font  font);
+
+
+HPDF_EXPORT(HPDF_INT)
+HPDF_Font_GetUnderlinePosition  (HPDF_Font  font);
+
+
+HPDF_EXPORT(HPDF_INT)
+HPDF_Font_GetUnderlineThickness  (HPDF_Font  font);
+
+
 HPDF_EXPORT(HPDF_UINT)
 HPDF_Font_GetXHeight  (HPDF_Font  font);
 

--- a/include/hpdf_fontdef.h
+++ b/include/hpdf_fontdef.h
@@ -96,6 +96,9 @@ typedef struct _HPDF_FontDef_Rec {
 
     HPDF_INT16    ascent;
     HPDF_INT16    descent;
+    HPDF_INT16    line_gap;
+    HPDF_INT16    underline_position;
+    HPDF_INT16    underline_thickness;
     HPDF_UINT     flags;
     HPDF_Box      font_bbox;
     HPDF_INT16    italic_angle;
@@ -305,6 +308,15 @@ typedef struct _HPDF_TTFontDefAttr_Rec {
     HPDF_UINT16              fs_type;
     HPDF_BYTE                sfamilyclass[2];
     HPDF_BYTE                panose[10];
+
+    HPDF_INT16               typo_ascender;
+    HPDF_INT16               typo_descender;
+    HPDF_INT16               typo_linegap;
+    HPDF_UINT16              win_ascent;
+    HPDF_UINT16              win_descent;
+    HPDF_INT16               underline_position;
+    HPDF_INT16               underline_thickness;
+
     HPDF_UINT32              code_page_range1;
     HPDF_UINT32              code_page_range2;
 
@@ -312,6 +324,9 @@ typedef struct _HPDF_TTFontDefAttr_Rec {
 
     HPDF_BOOL                embedding;
     HPDF_BOOL                is_cidfont;
+
+    HPDF_UINT                cff_offset;
+    HPDF_UINT                cff_length;
 
     HPDF_Stream              stream;
 } HPDF_TTFontDefAttr_Rec;

--- a/include/hpdf_mmgr.h
+++ b/include/hpdf_mmgr.h
@@ -38,6 +38,7 @@ typedef struct  _HPDF_MPool_Node_Rec {
 typedef struct  _HPDF_MMgr_Rec  *HPDF_MMgr;
 
 typedef struct  _HPDF_MMgr_Rec {
+    void*             pdf;
     HPDF_Error        error;
     HPDF_Alloc_Func   alloc_fn;
     HPDF_Free_Func    free_fn;

--- a/include/hpdf_streams.h
+++ b/include/hpdf_streams.h
@@ -148,6 +148,14 @@ HPDF_Stream_WriteToStream  (HPDF_Stream   src,
                             HPDF_UINT     filter,
                             HPDF_Encrypt  e);
 
+HPDF_STATUS
+HPDF_Stream_WriteToStream2 (HPDF_Stream   src,
+                            HPDF_Stream   dst,
+                            HPDF_UINT     filter,
+                            HPDF_Encrypt  e,
+                            HPDF_UINT     offset,
+                            HPDF_UINT     length);
+
 
 HPDF_Stream
 HPDF_FileReader_New  (HPDF_MMgr   mmgr,

--- a/src/hpdf_doc.c
+++ b/src/hpdf_doc.c
@@ -179,6 +179,8 @@ HPDF_NewEx  (HPDF_Error_Handler    user_error_fn,
     pdf->pdf_version = HPDF_VER_13;
     pdf->compression_mode = HPDF_COMP_NONE;
 
+    mmgr->pdf = pdf;
+
     /* copy the data of temporary-error object to the one which is
        included in pdf_doc object */
     pdf->error = tmp_error;

--- a/src/hpdf_fontdef_tt.c
+++ b/src/hpdf_fontdef_tt.c
@@ -140,6 +140,10 @@ static HPDF_STATUS
 ParseHmtx  (HPDF_FontDef  fontdef);
 
 
+static HPDF_BOOL ParseCFF  (HPDF_FontDef  fontdef);
+static HPDF_STATUS InitGlyphTbl (HPDF_FontDef  fontdef);
+
+
 static HPDF_STATUS
 ParseLoca  (HPDF_FontDef  fontdef);
 
@@ -156,6 +160,10 @@ ParseName  (HPDF_FontDef  fontdef);
 
 static HPDF_STATUS
 ParseOS2  (HPDF_FontDef  fontdef);
+
+
+static HPDF_STATUS
+ParsePost  (HPDF_FontDef  fontdef);
 
 
 static HPDF_TTFTable*
@@ -414,6 +422,7 @@ LoadFontData (HPDF_FontDef  fontdef,
     HPDF_TTFontDefAttr attr = (HPDF_TTFontDefAttr)fontdef->attr;
     HPDF_STATUS ret;
     HPDF_TTFTable *tbl;
+    HPDF_BOOL bCFF;
 
     HPDF_PTRACE ((" HPDF_TTFontDef_LoadFontData\n"));
 
@@ -445,8 +454,14 @@ LoadFontData (HPDF_FontDef  fontdef,
     if ((ret = ParseHmtx (fontdef)) != HPDF_OK)
         return ret;
 
-    if ((ret = ParseLoca (fontdef)) != HPDF_OK)
+    bCFF = ParseCFF(fontdef);    
+    if ((ret = InitGlyphTbl (fontdef)) != HPDF_OK)
         return ret;
+    if (!bCFF)
+    {
+        if ((ret = ParseLoca (fontdef)) != HPDF_OK)
+            return ret;
+    }
 
     if ((ret = ParseName (fontdef)) != HPDF_OK)
         return ret;
@@ -454,17 +469,35 @@ LoadFontData (HPDF_FontDef  fontdef,
     if ((ret = ParseOS2 (fontdef)) != HPDF_OK)
         return ret;
 
-    tbl = FindTable (fontdef, "glyf");
-    if (!tbl)
-        return HPDF_SetError (fontdef->error, HPDF_TTF_MISSING_TABLE, 4);
+    if ((ret = ParsePost (fontdef)) != HPDF_OK)
+        return ret;
 
-    attr->glyph_tbl.base_offset = tbl->offset;
-    fontdef->cap_height =
-                (HPDF_UINT16)HPDF_TTFontDef_GetCharBBox (fontdef, (HPDF_UINT16)'H').top;
-    fontdef->x_height =
-                (HPDF_UINT16)HPDF_TTFontDef_GetCharBBox (fontdef, (HPDF_UINT16)'x').top;
-    fontdef->missing_width = (HPDF_INT16)((HPDF_UINT32)attr->h_metric[0].advance_width * 1000 /
-                attr->header.units_per_em);
+    if (!bCFF) {
+        tbl = FindTable (fontdef, "glyf");
+        if (!tbl)
+            return HPDF_SetError (fontdef->error, HPDF_TTF_MISSING_TABLE, 4);
+
+        attr->glyph_tbl.base_offset = tbl->offset;
+        fontdef->stemv = 80;
+        fontdef->cap_height = (HPDF_UINT16)HPDF_TTFontDef_GetCharBBox (fontdef, (HPDF_UINT16)'H').top;
+        fontdef->x_height = (HPDF_UINT16)HPDF_TTFontDef_GetCharBBox (fontdef, (HPDF_UINT16)'x').top;
+        fontdef->missing_width = (HPDF_UINT32)attr->h_metric[0].advance_width * 1000 / attr->header.units_per_em;
+    }
+
+    if (fontdef->ascent == 0) {
+        fontdef->ascent = attr->typo_ascender;
+        fontdef->descent = attr->typo_descender;
+        fontdef->line_gap = attr->typo_linegap;
+    }    
+
+    if (fontdef->descent >= 0)
+        fontdef->descent = -fontdef->descent;
+
+
+    if (fontdef->underline_position == 0)
+        fontdef->underline_position = (attr->underline_position >= 0)? attr->underline_position : -attr->underline_position;
+    if (fontdef->underline_thickness == 0)
+        fontdef->underline_thickness = attr->underline_thickness;
 
     HPDF_PTRACE ((" fontdef->cap_height=%d\n", fontdef->cap_height));
     HPDF_PTRACE ((" fontdef->x_height=%d\n", fontdef->x_height));
@@ -845,6 +878,9 @@ ParseHhea (HPDF_FontDef  fontdef)
     ret += GetINT16 (attr->stream, &fontdef->descent);
     fontdef->descent = (HPDF_INT16)((HPDF_INT32)fontdef->descent * 1000 /
                 attr->header.units_per_em);
+    ret += GetINT16 (attr->stream, &fontdef->line_gap);
+    fontdef->line_gap = (HPDF_INT16)((HPDF_INT32)fontdef->line_gap * 1000 / 
+                attr->header.units_per_em);
 
     if (ret != HPDF_OK)
         return HPDF_Error_GetCode (fontdef->error);
@@ -874,6 +910,7 @@ ParseCMap (HPDF_FontDef  fontdef)
     HPDF_UINT16 num_cmap;
     HPDF_UINT i;
     HPDF_UINT32 ms_unicode_encoding_offset = 0;
+    HPDF_UINT32 up_unicode_encoding_offset = 0;
     HPDF_UINT32 byte_encoding_offset = 0;
 
     HPDF_PTRACE ((" HPDF_TTFontDef_ParseCMap\n"));
@@ -933,8 +970,12 @@ ParseCMap (HPDF_FontDef  fontdef)
         }
 
         /* Byte-Encoding-CMAP will be used if MS-Unicode-CMAP is not found */
-        if (platformID == 1 && encodingID ==0 && format == 1)
+        if (platformID == 1 && encodingID ==0 && format == 0)  // format 1 does not exist (!), see http://www.microsoft.com/typography/otspec/cmap.htm
             byte_encoding_offset = offset;
+
+        /* Unicode-Unicode-CMAP will be used if MS-Unicode-CMAP is not found */
+        if (platformID == 0 && encodingID == 3 && format == 4)
+            up_unicode_encoding_offset = offset;
 
         ret = HPDF_Stream_Seek (attr->stream, save_offset, HPDF_SEEK_SET);
         if (ret != HPDF_OK)
@@ -948,6 +989,9 @@ ParseCMap (HPDF_FontDef  fontdef)
     } else if (byte_encoding_offset != 0) {
         HPDF_PTRACE((" found byte encoding cmap.\n"));
         ret = ParseCMAP_format0(fontdef, byte_encoding_offset + tbl->offset);
+    } else if (up_unicode_encoding_offset != 0) {
+        HPDF_PTRACE((" found unicode platform unicode encoding cmap.\n"));
+        ret = ParseCMAP_format4(fontdef, up_unicode_encoding_offset + tbl->offset);
     } else {
         HPDF_PTRACE((" cannot found target cmap.\n"));
         return HPDF_SetError (fontdef->error, HPDF_TTF_INVALID_FOMAT, 0);
@@ -997,9 +1041,8 @@ ParseCMAP_format0  (HPDF_FontDef  fontdef,
 
     parray = attr->cmap.glyph_id_array;
     for (i = 0; i < 256; i++) {
-        *parray = attr->cmap.glyph_id_array[i];
-        HPDF_PTRACE((" ParseCMAP_format0 glyph_id_array[%d]=%u\n",
-                    i, *parray));
+        *parray = array[i];
+        HPDF_PTRACE((" ParseCMAP_format0 glyph_id_array[%d]=%u\n", i, *parray));
         parray++;
     }
 
@@ -1399,23 +1442,24 @@ ParseHmtx  (HPDF_FontDef  fontdef)
     return HPDF_OK;
 }
 
-static HPDF_STATUS
-ParseLoca  (HPDF_FontDef  fontdef)
+
+static HPDF_BOOL ParseCFF  (HPDF_FontDef  fontdef)
 {
     HPDF_TTFontDefAttr attr = (HPDF_TTFontDefAttr)fontdef->attr;
-    HPDF_TTFTable *tbl = FindTable (fontdef, "loca");
-    HPDF_STATUS ret;
-    HPDF_UINT i;
-    HPDF_UINT32 *poffset;
-
-    HPDF_PTRACE ((" HPDF_TTFontDef_ParseLoca\n"));
-
+    HPDF_TTFTable *tbl = FindTable (fontdef, "CFF ");
     if (!tbl)
-        return HPDF_SetError (fontdef->error, HPDF_TTF_MISSING_TABLE, 8);
+        return HPDF_FALSE;
 
-    ret = HPDF_Stream_Seek (attr->stream, tbl->offset, HPDF_SEEK_SET);
-    if (ret != HPDF_OK)
-        return ret;
+    attr->cff_offset = tbl->offset;
+    attr->cff_length = tbl->length;
+    return HPDF_TRUE;
+}
+
+
+
+static HPDF_STATUS InitGlyphTbl (HPDF_FontDef  fontdef)
+{
+    HPDF_TTFontDefAttr attr = (HPDF_TTFontDefAttr)fontdef->attr;
 
     /* allocate glyph-offset-table. */
     attr->glyph_tbl.offsets = HPDF_GetMem (fontdef->mmgr,
@@ -1439,6 +1483,27 @@ ParseLoca  (HPDF_FontDef  fontdef)
     HPDF_MemSet (attr->glyph_tbl.flgs, 0,
         sizeof (HPDF_BYTE) * attr->num_glyphs);
     attr->glyph_tbl.flgs[0] = 1;
+    return HPDF_OK;
+}
+
+
+static HPDF_STATUS
+ParseLoca  (HPDF_FontDef  fontdef)
+{
+    HPDF_TTFontDefAttr attr = (HPDF_TTFontDefAttr)fontdef->attr;
+    HPDF_TTFTable *tbl = FindTable (fontdef, "loca");
+    HPDF_STATUS ret;
+    HPDF_UINT i;
+    HPDF_UINT32 *poffset;
+
+    HPDF_PTRACE ((" HPDF_TTFontDef_ParseLoca\n"));
+
+    if (!tbl)
+        return HPDF_SetError (fontdef->error, HPDF_TTF_MISSING_TABLE, 8);
+
+    ret = HPDF_Stream_Seek (attr->stream, tbl->offset, HPDF_SEEK_SET);
+    if (ret != HPDF_OK)
+        return ret;
 
     poffset = attr->glyph_tbl.offsets;
     if (attr->header.index_to_loc_format == 0) {
@@ -1649,6 +1714,9 @@ ParseName  (HPDF_FontDef  fontdef)
     * if subfamily name is "Bold" or "Italic" or "BoldItalic", set flags
     * attribute.
     */
+    /*
+    // NOTE: font is already BOLD/ITALIC therefore do not do it again!
+    
     if (HPDF_MemCmp ((HPDF_BYTE *)tmp, (HPDF_BYTE *)"Regular", 7) != 0) {
         char *dst = attr->base_font + len_id1;
         char *src = tmp;
@@ -1670,7 +1738,7 @@ ParseName  (HPDF_FontDef  fontdef)
             fontdef->flags |= HPDF_FONT_FOURCE_BOLD;
         if (HPDF_StrStr (tmp, "Italic", len_id2))
             fontdef->flags |= HPDF_FONT_ITALIC;
-    }
+    }*/
 
     HPDF_MemCpy ((HPDF_BYTE *)fontdef->base_font, (HPDF_BYTE *)attr->base_font, HPDF_LIMIT_MAX_NAME_LEN + 1);
 
@@ -1755,22 +1823,76 @@ ParseOS2  (HPDF_FontDef  fontdef)
     if (attr->sfamilyclass[0] == 12)
         fontdef->flags = fontdef->flags | HPDF_FONT_SYMBOLIC;
 
-    /* get fields ulCodePageRange1 and ulCodePageRange2 */
-    if(version > 0) {
-        if ((ret = HPDF_Stream_Seek (attr->stream, 36, HPDF_SEEK_CUR)) != HPDF_OK)
-            return ret;
+    if ((ret = HPDF_Stream_Seek (attr->stream, tbl->offset + 68, HPDF_SEEK_SET)) != HPDF_OK)
+        return ret;
 
+    if ((ret = GetINT16(attr->stream, &attr->typo_ascender)) != HPDF_OK)
+        return ret;
+    if ((ret = GetINT16(attr->stream, &attr->typo_descender)) != HPDF_OK)
+        return ret;
+    if ((ret = GetINT16(attr->stream, &attr->typo_linegap)) != HPDF_OK)
+        return ret;
+    if ((ret = GetUINT16(attr->stream, &attr->win_ascent)) != HPDF_OK)
+        return ret;
+    if ((ret += GetUINT16(attr->stream, &attr->win_descent)) != HPDF_OK)
+        return ret;
+
+    attr->typo_ascender = (HPDF_INT16)((HPDF_INT32)attr->typo_ascender * 1000 / attr->header.units_per_em);
+    attr->typo_descender = (HPDF_INT16)((HPDF_INT32)attr->typo_descender * 1000 / attr->header.units_per_em);
+    attr->typo_linegap = (HPDF_INT16)((HPDF_INT32)attr->typo_linegap * 1000 / attr->header.units_per_em);
+    attr->win_ascent = (HPDF_INT16)((HPDF_INT32)attr->win_ascent * 1000 / attr->header.units_per_em);
+    attr->win_descent = (HPDF_INT16)((HPDF_INT32)attr->win_descent * 1000 / attr->header.units_per_em);
+
+    /* get fields ulCodePageRange1 and ulCodePageRange2 */
+    if (version > 0) {
+        // https://www.microsoft.com/typography/otspec/os2.htm
         if ((ret = GetUINT32 (attr->stream, &attr->code_page_range1)) != HPDF_OK)
-            return ret;
+            attr->code_page_range1 = 0; // not used
 
         if ((ret = GetUINT32 (attr->stream, &attr->code_page_range2)) != HPDF_OK)
-            return ret;
+            attr->code_page_range2 = 0; // not used
+
+        if (version > 1) {
+            if ((ret = GetUINT16 (attr->stream, &fontdef->x_height)) != HPDF_OK)
+                return ret;
+
+            if ((ret = GetUINT16 (attr->stream, &fontdef->cap_height)) != HPDF_OK)
+                return ret;
+        } else {
+            fontdef->cap_height = (int)(0.7 * attr->header.units_per_em);
+        }
     }
 
     HPDF_PTRACE(("  ParseOS2 CodePageRange1=%08X CodePageRange2=%08X\n",
                 (HPDF_UINT)attr->code_page_range1,
                 (HPDF_UINT)attr->code_page_range2));
 
+    return HPDF_OK;
+}
+
+
+static HPDF_STATUS
+ParsePost  (HPDF_FontDef  fontdef)
+{
+    HPDF_TTFontDefAttr attr = (HPDF_TTFontDefAttr)fontdef->attr;
+    HPDF_TTFTable *tbl = FindTable (fontdef, "post");
+    HPDF_STATUS ret;
+
+    HPDF_PTRACE ((" ParsePost\n"));
+
+    if (!tbl)
+        return HPDF_OK;
+
+    if ((ret = HPDF_Stream_Seek (attr->stream, tbl->offset + 8, HPDF_SEEK_SET)) != HPDF_OK)
+        return ret;
+
+    if ((ret = GetINT16(attr->stream, &attr->underline_position)) != HPDF_OK)
+        return ret;
+    if ((ret = GetINT16(attr->stream, &attr->underline_thickness)) != HPDF_OK)
+        return ret;
+
+    attr->underline_position = (HPDF_INT16)((HPDF_INT32)attr->underline_position * 1000 / attr->header.units_per_em);
+    attr->underline_thickness = (HPDF_INT16)((HPDF_INT32)attr->underline_thickness * 1000 / attr->header.units_per_em);
     return HPDF_OK;
 }
 

--- a/src/hpdf_streams.c
+++ b/src/hpdf_streams.c
@@ -72,7 +72,9 @@ HPDF_MemStream_InWrite  (HPDF_Stream      stream,
 HPDF_STATUS
 HPDF_Stream_WriteToStreamWithDeflate  (HPDF_Stream  src,
                                        HPDF_Stream  dst,
-                                       HPDF_Encrypt  e);
+                                       HPDF_Encrypt e,
+                                       HPDF_UINT    offset,
+                                       HPDF_UINT    length);
 
 
 HPDF_STATUS
@@ -560,7 +562,9 @@ HPDF_Stream_WriteBinary  (HPDF_Stream      stream,
 HPDF_STATUS
 HPDF_Stream_WriteToStreamWithDeflate  (HPDF_Stream  src,
                                        HPDF_Stream  dst,
-                                       HPDF_Encrypt  e)
+                                       HPDF_Encrypt  e,
+                                       HPDF_UINT    offset,
+                                       HPDF_UINT    length)
 {
 #ifdef LIBHPDF_HAVE_ZLIB
 
@@ -568,6 +572,7 @@ HPDF_Stream_WriteToStreamWithDeflate  (HPDF_Stream  src,
 
     HPDF_STATUS ret;
     HPDF_BOOL flg;
+    HPDF_UINT sizeleft = length;
 
     z_stream strm;
     Bytef inbuf[HPDF_STREAM_BUF_SIZ];
@@ -577,7 +582,7 @@ HPDF_Stream_WriteToStreamWithDeflate  (HPDF_Stream  src,
     HPDF_PTRACE((" HPDF_Stream_WriteToStreamWithDeflate\n"));
 
     /* initialize input stream */
-    ret = HPDF_Stream_Seek (src, 0, HPDF_SEEK_SET);
+    ret = HPDF_Stream_Seek (src, offset, HPDF_SEEK_SET);
     if (ret != HPDF_OK)
         return ret;
 
@@ -595,10 +600,18 @@ HPDF_Stream_WriteToStreamWithDeflate  (HPDF_Stream  src,
     strm.avail_in = 0;
 
     flg = HPDF_FALSE;
-    for (;;) {
+    for (;sizeleft > 0;) {
         HPDF_UINT size = HPDF_STREAM_BUF_SIZ;
 
         ret = HPDF_Stream_Read (src, inbuf, &size);
+
+        if (sizeleft >= size) {
+            sizeleft -= size;
+        } else {
+            size = sizeleft;
+            sizeleft = 0;
+            flg = HPDF_TRUE;
+        }
 
         strm.next_in = inbuf;
         strm.avail_in = size;
@@ -688,12 +701,24 @@ HPDF_STATUS
 HPDF_Stream_WriteToStream  (HPDF_Stream  src,
                             HPDF_Stream  dst,
                             HPDF_UINT    filter,
-                            HPDF_Encrypt  e)
+                            HPDF_Encrypt e)
+{
+    return HPDF_Stream_WriteToStream2(src, dst, filter, e, 0, -1);
+}
+
+HPDF_STATUS
+HPDF_Stream_WriteToStream2 (HPDF_Stream  src,
+                            HPDF_Stream  dst,
+                            HPDF_UINT    filter,
+                            HPDF_Encrypt e,
+                            HPDF_UINT    offset,
+                            HPDF_UINT    length)
 {
     HPDF_STATUS ret;
     HPDF_BYTE buf[HPDF_STREAM_BUF_SIZ];
     HPDF_BYTE ebuf[HPDF_STREAM_BUF_SIZ];
     HPDF_BOOL flg;
+    HPDF_UINT sizeleft = length;
 
     HPDF_PTRACE((" HPDF_Stream_WriteToStream\n"));
     HPDF_UNUSED (filter);
@@ -713,15 +738,15 @@ HPDF_Stream_WriteToStream  (HPDF_Stream  src,
 
 #ifdef LIBHPDF_HAVE_ZLIB
     if (filter & HPDF_STREAM_FILTER_FLATE_DECODE)
-        return HPDF_Stream_WriteToStreamWithDeflate (src, dst, e);
+        return HPDF_Stream_WriteToStreamWithDeflate (src, dst, e, offset, length);
 #endif /* LIBHPDF_HAVE_ZLIB */
 
-    ret = HPDF_Stream_Seek (src, 0, HPDF_SEEK_SET);
+    ret = HPDF_Stream_Seek (src, offset, HPDF_SEEK_SET);
     if (ret != HPDF_OK)
         return ret;
 
     flg = HPDF_FALSE;
-    for (;;) {
+    for (; sizeleft > 0;) {
         HPDF_UINT size = HPDF_STREAM_BUF_SIZ;
 
         ret = HPDF_Stream_Read (src, buf, &size);
@@ -734,6 +759,13 @@ HPDF_Stream_WriteToStream  (HPDF_Stream  src,
             } else {
                 return ret;
             }
+        }
+
+        if (sizeleft >= size) {
+            sizeleft -= size;
+        } else {
+            size = sizeleft;
+            sizeleft = 0;
         }
 
         if (e) {


### PR DESCRIPTION
HPDF_LoadTTFontFromFile is now able to load OpenType fonts (*.otf; Adobe type1 "CFF " table).

HPDF_MMgr was extended with a pointer to the parent HPDF_Doc structure, so the font dictionary encoding can depend on the runtime selection of the output PDF version.

Supersedes #142 which doesn't apply to 2.4.x. 