### PR TITLE
Add support for Apple-Frameworks builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 
 file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/include/hpdf_version.h HPDF_VERSION_H_CONTENTS REGEX " HPDF_(MAJOR|MINOR|BUGFIX)_VERSION ")
 string(REGEX MATCH "MAJOR_VERSION [0-9]+"  HPDF_MAJOR_VERSION  ${HPDF_VERSION_H_CONTENTS})
@@ -8,8 +8,11 @@ string(REGEX MATCH "[0-9]+" HPDF_MAJOR_VERSION  ${HPDF_MAJOR_VERSION})
 string(REGEX MATCH "[0-9]+" HPDF_MINOR_VERSION  ${HPDF_MINOR_VERSION})
 string(REGEX MATCH "[0-9]+" HPDF_BUGFIX_VERSION ${HPDF_BUGFIX_VERSION})
 
+set(hpdf_short_version ${HPDF_MAJOR_VERSION}.${HPDF_MINOR_VERSION})
+set(hpdf_full_version ${HPDF_MAJOR_VERSION}.${HPDF_MINOR_VERSION}.${HPDF_BUGFIX_VERSION})
+
 project(libharu
-    VERSION ${HPDF_MAJOR_VERSION}.${HPDF_MINOR_VERSION}.${HPDF_BUGFIX_VERSION}
+    VERSION ${hpdf_full_version}
     DESCRIPTION "libHaru is a free, cross platform, open source library for generating PDF files."
     LANGUAGES C)
 
@@ -26,6 +29,10 @@ option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static on
 option(LIBHPDF_EXAMPLES "Build libharu examples" OFF)
 option(LIBHPDF_DEBUG "Enable HPDF Debug")
 option(LIBHPDF_DEBUG_TRACE "Enable HPDF Debug trace")
+
+if (APPLE)
+  option(BUILD_FRAMEWORK "Build as Apple Frameworks" OFF)
+endif()
 
 # Enable exceptions on linux if required
 # (eg if you are using libharu in a C++ environment,
@@ -138,6 +145,7 @@ set(
 
 # install header files
 install(FILES ${haru_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+# install(FILES ${haru_HDRS} DESTINATION Library/Frameworks)
 
 # install various files
 install(FILES README.md CHANGES INSTALL DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/libharu)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,14 +70,75 @@ set(
     hpdf_encoder_utf.c
 )
 
+# FIXME: Redeclaration
+set(
+  haru_HDRS
+    ${PROJECT_SOURCE_DIR}/include/hpdf.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_types.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_consts.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_annotation.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_catalog.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_conf.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_destination.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_doc.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_encoder.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_encrypt.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_encryptdict.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_error.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_ext_gstate.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_font.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_fontdef.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_gstate.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_image.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_info.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_list.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_mmgr.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_namedict.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_objects.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_outline.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_pages.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_page_label.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_streams.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_u3d.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_utils.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_pdfa.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_3dmeasure.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_exdata.h
+    ${PROJECT_SOURCE_DIR}/include/hpdf_version.h
+    ${PROJECT_BINARY_DIR}/include/hpdf_config.h
+)
+
 # =======================================================================
 # create hpdf library
 # =======================================================================
-add_library(hpdf ${LIBHPDF_SRCS})
+add_library(hpdf 
+    ${LIBHPDF_SRCS} 
+    ${haru_HDRS})
+# target_include_directories(hpdf PUBLIC
+#                         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
+#                         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hpdf>")
+target_include_directories(hpdf PUBLIC ${PROJECT_SOURCE_DIR}/include)
+# target_include_directories(hpdf PUBLIC ${haru_HDRS})
 set_target_properties(hpdf PROPERTIES
-    SOVERSION ${HPDF_MAJOR_VERSION}.${HPDF_MINOR_VERSION}
-    VERSION ${HPDF_MAJOR_VERSION}.${HPDF_MINOR_VERSION}.${HPDF_BUGFIX_VERSION}
+    SOVERSION ${hpdf_short_version}
+    VERSION ${hpdf_full_version}
 )
+
+if (BUILD_FRAMEWORK)
+    set_target_properties(hpdf PROPERTIES
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION "${hpdf_full_version}"
+        PUBLIC_HEADER "${haru_HDRS}"
+        PRODUCT_BUNDLE_IDENTIFIER "github.com/libharu/libharu"
+        XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+        OUTPUT_NAME "hpdf"
+        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+        MACOSX_FRAMEWORK_IDENTIFIER "github.com/libharu/libharu"
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${hpdf_short_version}"
+        MACOSX_FRAMEWORK_BUNDLE_VERSION "${hpdf_full_version}"
+    )
+endif ()
+
 if (PNG_FOUND)
     include_directories (${PNG_INCLUDE_DIRS})
     target_link_libraries (hpdf ${PNG_LIBRARIES})
@@ -92,9 +153,14 @@ if(UNIX AND NOT APPLE)
     target_link_libraries (hpdf ${M_LIB})
 endif()
 
-install(
-   TARGETS hpdf
-   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+# install(FILES ${haru_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(TARGETS hpdf
+    EXPORT hpdf
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    FRAMEWORK DESTINATION Library/Frameworks COMPONENT runtime OPTIONAL
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )


### PR DESCRIPTION
Greetings,

Cross-compilation for a macOS target was already supported within this framework. To enable iOS compilations, I bumped CMake's version to 3.14 and introduced a new flag, `BUILD_FRAMEWORK`, which is set to FALSE by default.
```bash
cmake -S. -B build -DBUILD_FRAMEWORK=TRUE -DCMAKE_SYSTEM_NAME=iOS

sudo cmake --build build --target install --config Release
```
The resulting iOS binaries can then be found in: `build/src/hpdf.framework`


The headers were not copied to the build directory, even though they were intended to be installed there. 
https://github.com/libharu/libharu/blob/0c598becaadaef8e3d12b883f9fc2864a118c12d/CMakeLists.txt#L144C1-L144C77


Unfortunately, I couldn't determine the reason for this issue. As a temporary solution, I duplicated the `haru_HDRS` declaration in the `hpdf` target, which resolved the problem. The headers were successfully added to the framework bundle.
