### PR TITLE
Fix linking error due to nonexistent function in win32/msvc/libhpdf.def

### DIFF
--- a/win32/msvc/libhpdf.def
+++ b/win32/msvc/libhpdf.def
@@ -1,7 +1,6 @@
 LIBRARY     LIBHPDF.DLL
 
 EXPORTS
-    HPDF_3DAnnot_Set3DView
     HPDF_3DView_AddNode
     HPDF_3DView_SetBackgroundColor
     HPDF_3DView_SetCamera


### PR DESCRIPTION
The function `HPDF_3DAnnot_Set3DView` was removed from the code in ac6052c588e7a6ade5d65c4a29d1a810b6c0e848 and should also be removed from `win32/msvc/libhpdf.def` otherwise it causes linking errors ( LNK2001: unresolved external symbol).