### PR TITLE
Fix dash mode type in demo/line_demo.c

### DIFF
--- a/demo/line_demo.c
+++ b/demo/line_demo.c
@@ -89,9 +89,9 @@ int main (int argc, char **argv)
     HPDF_Page page;
     char fname[256];
 
-    const HPDF_UINT16 DASH_MODE1[] = {3};
-    const HPDF_UINT16 DASH_MODE2[] = {3, 7};
-    const HPDF_UINT16 DASH_MODE3[] = {8, 7, 2, 7};
+    const HPDF_REAL DASH_MODE1[] = {3.0};
+    const HPDF_REAL DASH_MODE2[] = {3.0, 7.0};
+    const HPDF_REAL DASH_MODE3[] = {8.0, 7.0, 2.0, 7.0};
 
     double x;
     double y;


### PR DESCRIPTION
The demo file is still using `HPDF_UINT16` instead of the new `HPDF_REAL` type.