### PR TITLE
Add function to attach file from memory

### DIFF
--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -992,6 +992,11 @@ HPDF_EXPORT(HPDF_EmbeddedFile)
 HPDF_AttachFile  (HPDF_Doc    pdf,
                   const char *file);
 
+HPDF_EXPORT(HPDF_Image)
+HPDF_AttachFileFromMem  (HPDF_Doc         pdf,
+                         const char       *filename,
+                         const HPDF_BYTE  *buffer,
+                         HPDF_UINT        size);
 
 /*--------------------------------------------------------------------------*/
 /*----- extended graphics state --------------------------------------------*/

--- a/include/hpdf_namedict.h
+++ b/include/hpdf_namedict.h
@@ -62,7 +62,8 @@ HPDF_NameTree_Validate  (HPDF_NameTree  tree);
 HPDF_EmbeddedFile
 HPDF_EmbeddedFile_New  (HPDF_MMgr  mmgr,
                         HPDF_Xref  xref,
-                        const char *file);
+                        const char *filename,
+                        HPDF_Stream  stream);
 
 HPDF_BOOL
 HPDF_EmbeddedFile_Validate  (HPDF_EmbeddedFile  emfile);

--- a/src/hpdf_namedict.c
+++ b/src/hpdf_namedict.c
@@ -171,14 +171,15 @@ HPDF_NameTree_Validate  (HPDF_NameTree  nametree)
 HPDF_EmbeddedFile
 HPDF_EmbeddedFile_New  (HPDF_MMgr  mmgr,
                         HPDF_Xref  xref,
-                        const char *file)
+                        const char *filename,
+                        HPDF_Stream  stream)
 {
     HPDF_STATUS ret = HPDF_OK;
     HPDF_Dict ef;               /* the dictionary for the embedded file: /Type /EF */
     HPDF_String name;           /* the name of the file: /F (name) */
+    HPDF_String uname;          /* the name of the file: /UF (name) */
     HPDF_Dict eff;              /* ef has an /EF <<blah>> key - this is it */
     HPDF_Dict filestream;       /* the stream that /EF <</F _ _ R>> refers to */
-    HPDF_Stream stream;
 
     ef = HPDF_Dict_New (mmgr);
     if (!ef)
@@ -189,7 +190,6 @@ HPDF_EmbeddedFile_New  (HPDF_MMgr  mmgr,
     filestream = HPDF_DictStream_New (mmgr, xref);
     if (!filestream)
         return NULL;
-    stream = HPDF_FileReader_New (mmgr, file);
     if (!stream)
         return NULL;
     HPDF_Stream_Free(filestream->stream);
@@ -200,13 +200,18 @@ HPDF_EmbeddedFile_New  (HPDF_MMgr  mmgr,
     if (!eff)
         return NULL;
 
-    name = HPDF_String_New (mmgr, file, NULL);
+    name = HPDF_String_New (mmgr, filename, NULL);
     if (!name)
         return NULL;
 
-    ret += HPDF_Dict_AddName (ef, "Type", "F");
+    uname = HPDF_String_New (mmgr, filename, NULL);
+    if (!uname)
+        return NULL;
+
+    ret += HPDF_Dict_AddName (ef, "Type", "Filespec");
     ret += HPDF_Dict_Add (ef, "F", name);
     ret += HPDF_Dict_Add (ef, "EF", eff);
+    ret += HPDF_Dict_Add (ef, "UF", uname);
     ret += HPDF_Dict_Add (eff, "F", filestream);
 
     if (ret != HPDF_OK)


### PR DESCRIPTION
This PR contains a suggestion to add a new function `HPDF_AttachFileFromMem` that attaches an embedded file passing their content instead of its file path.

As it is already the case for other functions that include images (e.g `HPDF_LoadPngImageFromMem`), if the files are already loaded into memory it would be much more efficient to have a method that directly attaches the files taking them from a stream instead of forcing the user to write them to a file, pass it to libharu than it will then read it again.