### PR TITLE
Fix various typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,7 +32,7 @@ Version 2.2.0 (2010.10.12)
     - Markup Annotations
     - Free Text Annotations
     - Line Annotations
-    - Circle and Squre Annotations
+    - Circle and Square Annotations
     - Text Markup Annotations
     - Rubber Stamp Annotations
     - Popup Annotations	

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ to the following restrictions:
    We wish to thank all users of Haru.
    In particular, we thank Thomas Nimstad, LeslieM, Par Hogberg, adenelson, 
    Riccardo Cohen, sea_sbs, Andrew. 
-   They gave me very useful advices.
+   They gave me very useful advice.
 
 3. Adobe Systems Inc.
    We thank Adobe Systems Inc. for publishing PDF specification.

--- a/README_cmake
+++ b/README_cmake
@@ -62,8 +62,8 @@ You get a complete list of all available generators for your platform
 with "cmake --help". I'll go into details for one specific compiler toolset.
 The other generators work similar.
 
-Using CMake to produce Visual C++ 2008 Makfiles
------------------------------------------------
+Using CMake to produce Visual C++ 2008 Makefiles
+------------------------------------------------
 First you need to have the command line interface setup correctly. Start
 cmd.exe and run "%VS90COMNTOOLS%vsvars32.bat". This will set up the
 command line tools of Visual C++ 2008. Cd into the created build

--- a/bindings/c#/demo/FontDemo.cs
+++ b/bindings/c#/demo/FontDemo.cs
@@ -65,7 +65,7 @@ public class FontDemo {
             /* output subtitle. */
             page.BeginText();
             page.SetFontAndSize(def_font, 16);
-            page.TextOut(60, height - 80, "<Standerd Type1 fonts samples>");
+            page.TextOut(60, height - 80, "<Standard Type1 fonts samples>");
             page.EndText();
 
             page.BeginText();

--- a/bindings/oberon-2/test.ob2
+++ b/bindings/oberon-2/test.ob2
@@ -114,7 +114,7 @@ BEGIN
 
     h.HPDF_Page_SetFontAndSize (page, font, 10);
 
-    (* Draw verious widths of lines. *)
+    (* Draw various widths of lines. *)
     h.HPDF_Page_SetLineWidth (page, 0);
     draw_line (page, 60, 770, w.GetPSTR('толщина линии := 0'));
 

--- a/bindings/python/demo/font_demo.py
+++ b/bindings/python/demo/font_demo.py
@@ -98,7 +98,7 @@ def main ():
     # output subtitle.
     HPDF_Page_BeginText (page)
     HPDF_Page_SetFontAndSize (page, def_font, 16)
-    HPDF_Page_TextOut (page, 60, height - 80, "<Standerd Type1 fonts samples>")
+    HPDF_Page_TextOut (page, 60, height - 80, "<Standard Type1 fonts samples>")
     HPDF_Page_EndText (page)
 
     HPDF_Page_BeginText (page)

--- a/bindings/ruby/demo/font_demo.rb
+++ b/bindings/ruby/demo/font_demo.rb
@@ -33,7 +33,7 @@ tw = page.text_width(title)
 page.begin_text
 page.text_out((width - tw) / 2, height - 50.0, title)
 page.set_font_and_size(font1, 16.0)
-page.text_out(60.0, height - 80.0, "<Standerd Type1 fonts samples>")
+page.text_out(60.0, height - 80.0, "<Standard Type1 fonts samples>")
 page.end_text
 
 samp_text = "abcdefgABCDEFG12345!#$\%&+-@?"

--- a/bindings/vb6/Form1.frm
+++ b/bindings/vb6/Form1.frm
@@ -241,7 +241,7 @@ Private Sub Command1_Click()
     ' * Rotating text
     ' */
     angle1 = 30                   '/* A rotation of 30 degrees. */
-    rad1 = angle1 / 180 * 3.141592 '/* Calcurate the radian value. */
+    rad1 = angle1 / 180 * 3.141592 '/* Calculate the radian value. */
 
     Call show_description(page, 320, ypos - 60, "Rotating text")
     Call HPDF_Page_BeginText(page)

--- a/demo/font_demo.c
+++ b/demo/font_demo.c
@@ -103,7 +103,7 @@ int main (int argc, char **argv)
     /* output subtitle. */
     HPDF_Page_BeginText (page);
     HPDF_Page_SetFontAndSize (page, def_font, 16);
-    HPDF_Page_TextOut (page, 60, height - 80, "<Standerd Type1 fonts samples>");
+    HPDF_Page_TextOut (page, 60, height - 80, "<Standard Type1 fonts samples>");
     HPDF_Page_EndText (page);
 
     HPDF_Page_BeginText (page);

--- a/demo/font_demo.cpp
+++ b/demo/font_demo.cpp
@@ -98,7 +98,7 @@ int main (int argc, char **argv)
         HPDF_Page_BeginText (page);
         HPDF_Page_MoveTextPos (page, 60, height - 80);
         HPDF_Page_SetFontAndSize (page, def_font, 16);
-        HPDF_Page_ShowText (page, "<Standerd Type1 fonts samples>");
+        HPDF_Page_ShowText (page, "<Standard Type1 fonts samples>");
         HPDF_Page_EndText (page);
 
         HPDF_Page_BeginText (page);

--- a/demo/type1/README
+++ b/demo/type1/README
@@ -6,7 +6,7 @@ Cyrillized free URW fonts.
 These fonts were made from the free URW fonts distributed with ghostscript.
 There are NO changes in the latin part of them (I hope).
 Cyrillic glyphs were added by copying suitable latin ones
-and painting oulines of unique cyrillic glyphs in same style as the others.
+and painting outlines of unique cyrillic glyphs in same style as the others.
 For all modification pfaedit was used.
 The license for result is (of course) same as for original fonts,
 i.e. GPL with an exception that you can put these fonts in your own non-GPLed

--- a/src/hpdf_page_operator.c
+++ b/src/hpdf_page_operator.c
@@ -300,7 +300,7 @@ HPDF_Page_SetExtGState  (HPDF_Page        page,
     if (HPDF_Stream_WriteStr (attr->stream, " gs\012") != HPDF_OK)
         return HPDF_CheckError (page->error);
 
-    /* change objct class to read only. */
+    /* change object class to read only. */
     ext_gstate->header.obj_class = (HPDF_OSUBCLASS_EXT_GSTATE_R | HPDF_OCLASS_DICT);
 
     return ret;

--- a/src/hpdf_pdfa.c
+++ b/src/hpdf_pdfa.c
@@ -348,7 +348,7 @@ HPDF_PDFA_AddXmpMetadata(HPDF_Doc pdf)
         /* Update the PDF number version */
         pdf->pdf_version = (pdf->pdf_version > conformanceVersion ? pdf->pdf_version : conformanceVersion);
 
-        /* Append additionnal specific XMP extensions */
+        /* Append additional specific XMP extensions */
         {
             HPDF_UINT i;
             HPDF_List list;

--- a/src/hpdf_streams.c
+++ b/src/hpdf_streams.c
@@ -110,7 +110,7 @@ HPDF_FileStream_FreeFunc  (HPDF_Stream  stream);
  *
  *  stream : Pointer to a HPDF_Stream object.
  *  ptr : Pointer to a buffer to copy read data.
- *  size : Pointer to a variable which indecates buffer size.
+ *  size : Pointer to a variable which indicates buffer size.
  *
  *  HPDF_Stream_read returns HPDF_OK when success. On failure, it returns
  *  error-code returned by reading function of this stream.


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.pdf,./demo/pdf_a/factur-x.xml" -L appearence,ba,coo,fith,fo,nam,opend,ro,siz,suppliment,te`