### PR TITLE
fix Build error for Win32 (x86) due to modifier mismatch #350

### DIFF
--- a/src/hpdf_pdfa.c
+++ b/src/hpdf_pdfa.c
@@ -144,7 +144,7 @@ HPDF_STATUS ConvertDateToXMDate(HPDF_Stream stream, const char *pDate)
 }
 
 /* Set PDF/A conformance */
-HPDF_STATUS
+HPDF_EXPORT(HPDF_STATUS)
 HPDF_PDFA_SetPDFAConformance (HPDF_Doc pdf, HPDF_PDFAType pdfatype)
 {
     pdf->pdfa_type = pdfatype;


### PR DESCRIPTION
fix: fix missing `HPDF__EXPORT` in `HPDF_PDFA_SetPDFAConformance` function definition


Closes #350 