### PR TITLE
hpdf_utils: bound HPDF_FToA fractional writes against eptr

### DIFF
--- a/src/hpdf_utils.c
+++ b/src/hpdf_utils.c
@@ -229,11 +229,17 @@ HPDF_FToA  (char       *s,
     while (s <= eptr && *t != 0)
         *s++ = *t--;
 
-    /* process fractional part */
-    *s++ = '.';
+    /* Bound the fractional writes against eptr, matching the integer
+     * copy loop above. Without this, callers that share one stack
+     * buffer across many HPDF_FToA calls (e.g. HPDF_Page_Ellipse)
+     * overflow it. */
+    if (s <= eptr)
+        *s++ = '.';
     if (fpart_val != 0.0) {
         HPDF_UINT32 i;
         for (i = 0; i < prec; i++) {
+            if (s > eptr)
+                break;
             fpart_val = modff(fpart_val*10.0f, &int_val);
             *s++ = (char)(int_val + 0.5) + '0';
         }


### PR DESCRIPTION
The fractional-write section of `HPDF_FToA` doesn't check `eptr` like the integer copy above. For small `val` (e.g. `1e-20`), `prec` grows to ~35 fractional digits; `HPDF_Page_Ellipse` issues 25 `HPDF_FToA` calls into one 512-byte stack buffer and overflows it.

Reproducer (clang `-fsanitize=address`):

```c
HPDF_Page_Ellipse(page, 1e-20f, 2e-20f, 3e-20f, 4e-20f);
HPDF_Page_Stroke(page);
```

ASan trace:

```
stack-buffer-overflow WRITE size 1 at offset 544 of buf[512]
  #0 HPDF_FToA              hpdf_utils.c:238
  #1 QuarterEllipseD        hpdf_page_operator.c:2143
  #2 HPDF_Page_Ellipse      hpdf_page_operator.c:2180
```

Same primitive as CVE-2006-6146. That fix enlarged the `HPDF_Page_Circle` buffer; it didn't patch `HPDF_FToA`, so every other coordinate-emitting primitive still hits the issue.

Normal `HPDF_Page_Ellipse`/`Circle`/`Arc` calls emit the same content stream as before the patch.