### PR TITLE
hpdf_image_png: reject IHDR dimensions that overflow width*height

### DIFF
--- a/src/hpdf_image_png.c
+++ b/src/hpdf_image_png.c
@@ -22,6 +22,7 @@
 #ifdef LIBHPDF_HAVE_LIBPNG
 #include <png.h>
 #include <string.h>
+#include <limits.h>
 
 static void
 PngErrorFunc  (png_structp       png_ptr,
@@ -478,6 +479,17 @@ LoadPngData  (HPDF_Dict     image,
 
 	png_read_update_info(png_ptr, info_ptr);
 	if (image->error->error_no != HPDF_OK) {
+		goto Exit;
+	}
+
+	/* Reject dimensions whose width*height overflows HPDF_UINT. The
+	 * smask alpha buffer below is sized by that product; without this
+	 * check, a crafted IHDR wraps the multiplication and the decode
+	 * loop writes width*height bytes into an undersized allocation.
+	 * Checked before HPDF_DictStream_New so the early-out doesn't
+	 * leave a half-constructed xref-owned object. */
+	if (width != 0 && height > UINT_MAX / width) {
+		ret = HPDF_INVALID_PNG_IMAGE;
 		goto Exit;
 	}
 


### PR DESCRIPTION
A crafted PNG with `width=65537, height=65536` wraps the true `width*height` product (`4 295 032 832`) to `65 536` in `HPDF_UINT`. The smask alpha buffer is sized from that wrapped value, and the decode loops in `ReadTransparentPaletteData` / `ReadTransparentPngData` then write `width*height` bytes into the undersized allocation.

Both the palette and RGBA paths share the `width`/`height` from `png_get_image_*`, so one check after `png_read_update_info` covers both. Running it before `HPDF_DictStream_New` keeps the failure path from constructing an xref-owned object that the existing cleanup paths would then double-free during `HPDF_Free`.

Instrumented confirmation:

```
[probe] width=65537 height=65536
        width*height (32-bit unsigned)=65536 (true product=4295032832)
```

With this check, `HPDF_LoadPngImageFromMem` returns NULL on the crafted input; a 4x4 RGBA PNG still loads.