### PR TITLE
hpdf_pages: fix off-by-one in HPDF_Page_SetSize range check

### DIFF
--- a/src/hpdf_pages.c
+++ b/src/hpdf_pages.c
@@ -1659,7 +1659,7 @@ HPDF_Page_SetSize  (HPDF_Page             page,
     if (!HPDF_Page_Validate (page))
         return HPDF_INVALID_PAGE;
 
-    if (size < 0 || size > HPDF_PAGE_SIZE_EOF)
+    if (size < 0 || size >= HPDF_PAGE_SIZE_EOF)
         return HPDF_RaiseError (page->error, HPDF_PAGE_INVALID_SIZE,
                 (HPDF_STATUS)direction);
 


### PR DESCRIPTION
`HPDF_PREDEFINED_PAGE_SIZES` has 12 entries (indices `0`..`11`). `HPDF_PAGE_SIZE_EOF` is the past-the-end sentinel (`= 12`), but the range check uses `>` instead of `>=`:

```c
if (size < 0 || size > HPDF_PAGE_SIZE_EOF)
    return HPDF_RaiseError(...);
```

`HPDF_PAGE_SIZE_EOF` passes validation, and the next statement reads `HPDF_PREDEFINED_PAGE_SIZES[12]`, one past the array end (8-byte rodata over-read).