### PR TITLE
hpdf_encrypt: zero the full MD5 context in HPDF_MD5Final

### DIFF
--- a/src/hpdf_encrypt.c
+++ b/src/hpdf_encrypt.c
@@ -168,7 +168,7 @@ HPDF_MD5Final  (HPDF_BYTE              digest[16],
     MD5Transform (ctx->buf, (HPDF_UINT32 *) ctx->in);
     MD5ByteReverse ((HPDF_BYTE *) ctx->buf, 4);
     HPDF_MemCpy ((HPDF_BYTE *)digest, (HPDF_BYTE *)ctx->buf, 16);
-    HPDF_MemSet ((HPDF_BYTE *)ctx, 0, sizeof (ctx));   /* In case it's sensitive */
+    HPDF_MemSet ((HPDF_BYTE *)ctx, 0, sizeof (*ctx));  /* In case it's sensitive */
 }
 
 /* The four core functions - F1 is optimized somewhat */


### PR DESCRIPTION
`HPDF_MemSet ((HPDF_BYTE *)ctx, 0, sizeof (ctx))` only zeroes `sizeof(ctx)`, i.e. the size of the *pointer* (4 or 8 bytes), not the 88-byte `HPDF_MD5Context`. The digest buffer and the 64-byte input block that just held key material survive in heap until the surrounding mpool frees.

Replace with `sizeof (*ctx)`.

Same defect ships verbatim in the 1993 Colin Plumb reference MD5 source this code is derived from.