### PR TITLE
hpdf_image_png: bound PngErrorFunc message scan by NUL

### DIFF
--- a/src/hpdf_image_png.c
+++ b/src/hpdf_image_png.c
@@ -96,8 +96,10 @@ PngErrorFunc  (png_structp       png_ptr,
     HPDF_MemSet (error_number, 0, 16);
 
      for (i = 0; i < 15; i++) {
-         error_number[i] = *(msg + i);
-         if (*(msg + i + 1) == ' ')
+         if (msg[i] == 0)
+             break;
+         error_number[i] = msg[i];
+         if (msg[i + 1] == 0 || msg[i + 1] == ' ')
              break;
      }
 


### PR DESCRIPTION
`PngErrorFunc` scans up to 15 bytes of the libpng error message looking for a space-terminated leading error number:

```c
for (i = 0; i < 15; i++) {
    error_number[i] = *(msg + i);
    if (*(msg + i + 1) == ' ')
        break;
}
```

The loop checks `msg[i+1] == ' '` but never tests for the NUL terminator. A libpng message shorter than 16 bytes whose prefix contains no space causes the loop to walk past the end of the string into adjacent memory (heap or stack, depending on how libpng allocated the buffer).

Fix terminates on either NUL or space, and bails early if the byte we're about to copy is already NUL.