### PR TITLE
hpdf_encoder_utf: mask continuation byte in 4-byte UTF-8 decode

### DIFF
--- a/src/hpdf_encoder_utf.c
+++ b/src/hpdf_encoder_utf.c
@@ -146,9 +146,9 @@ UTF8_Encoder_ToUnicode_Func  (HPDF_Encoder   encoder,
 
     switch (utf8_attr->end_byte) {
     case 3:
-	val = (unsigned int) ((utf8_attr->utf8_bytes[0] & 0x7) << 18) +
-	    (unsigned int) ((utf8_attr->utf8_bytes[1]) << 12)       +
-	    (unsigned int) ((utf8_attr->utf8_bytes[2] & 0x3f) << 6) +
+	val = (unsigned int) ((utf8_attr->utf8_bytes[0] & 0x7)  << 18) +
+	    (unsigned int) ((utf8_attr->utf8_bytes[1] & 0x3f) << 12) +
+	    (unsigned int) ((utf8_attr->utf8_bytes[2] & 0x3f) <<  6) +
 	    (unsigned int) ((utf8_attr->utf8_bytes[3] & 0x3f));
 	break;
     case 2:


### PR DESCRIPTION
The 4-byte form of `UTF8_Encoder_ToUnicode_Func` masks all continuation bytes except the first:

```c
val = (bytes[0] & 0x7) << 18
    + (bytes[1])       << 12       /* missing & 0x3f */
    + (bytes[2] & 0x3f) << 6
    + (bytes[3] & 0x3f);
```

A malformed continuation byte (top two bits other than `10`) leaks its high bits into bits 12-13 of the decoded codepoint, shifting it into an arbitrary range. The `> 65535` clamp below catches values past UCS-2 but values that wrap back into 16-bit can still misindex the CID map.

The 3-byte case (just above) masks correctly with `& 0xf` / `& 0x3f`; this patch restores the same symmetry for the 4-byte case.