### PR TITLE
hpdf_utils: reject non-finite val in HPDF_FToA

### DIFF
--- a/src/hpdf_utils.c
+++ b/src/hpdf_utils.c
@@ -192,10 +192,14 @@ HPDF_FToA  (char       *s,
     HPDF_INT32 logVal;
     HPDF_UINT32 prec;
 
-    if (val > HPDF_LIMIT_MAX_REAL)
+    /* isnan/isinf check first: both > and < below are false for NaN,
+     * so a NaN input would otherwise pass through to log10/modff and
+     * produce undefined output. */
+    if (isnan(val) || isinf(val))
+        val = 0.0f;
+    else if (val > HPDF_LIMIT_MAX_REAL)
         val = HPDF_LIMIT_MAX_REAL;
-    else
-    if (val < HPDF_LIMIT_MIN_REAL)
+    else if (val < HPDF_LIMIT_MIN_REAL)
         val = HPDF_LIMIT_MIN_REAL;
 
     t = buf;


### PR DESCRIPTION
The existing clamps:

```c
if (val > HPDF_LIMIT_MAX_REAL)
    val = HPDF_LIMIT_MAX_REAL;
else if (val < HPDF_LIMIT_MIN_REAL)
    val = HPDF_LIMIT_MIN_REAL;
```

are both false for `NaN` and `infinity`. `log10(NaN) = NaN`, `modff(NaN, &int_val) = NaN`, and the subsequent `(HPDF_INT32)log10(val)` cast of an out-of-range floating-point value is undefined behavior per C11 6.3.1.4. The integer-write loop emits a junk byte and the produced PDF number is malformed.

Snap non-finite inputs to `0.0f` before the rest of the function runs.