### PR TITLE
hpdf_dict: roll back element when HPDF_Proxy_New fails in HPDF_Dict_Add

### DIFF
--- a/src/hpdf_dict.c
+++ b/src/hpdf_dict.c
@@ -348,7 +348,13 @@ HPDF_Dict_Add  (HPDF_Dict        dict,
         HPDF_Proxy proxy = HPDF_Proxy_New (dict->mmgr, obj);
 
         if (!proxy) {
-            HPDF_Obj_Free(dict->mmgr, obj);
+            /* Don't leave the element with value==NULL: subsequent
+             * HPDF_Dict_GetItem dereferences element->value without
+             * a NULL check. Remove the element so a later lookup
+             * returns "not found" rather than crashing. */
+            HPDF_List_Remove (dict->list, element);
+            HPDF_FreeMem (dict->mmgr, element);
+            HPDF_Obj_Free (dict->mmgr, obj);
             return HPDF_Error_GetCode (dict->error);
         }
 


### PR DESCRIPTION
When `HPDF_Dict_Add` takes the indirect-object path and `HPDF_Proxy_New` returns NULL, the function returns an error but leaves the dict element with `element->value == NULL`. `HPDF_Dict_GetItem` at line 430 then dereferences `element->value` without a NULL check, so any subsequent lookup of the same key crashes during what looks like a normal read:

```c
HPDF_Obj_Header *header = (HPDF_Obj_Header *)element->value;
```

Same shape as the long-open #71 ("Crashing on HPDF_Free()") and similar to issue #63.

Remove the element from the dict's list and free it before returning the allocation error, so a later lookup returns "not found" rather than crashing.